### PR TITLE
Issue #19

### DIFF
--- a/language/src/main/java/com/vztekoverflow/bacil/BACILEngineOption.java
+++ b/language/src/main/java/com/vztekoverflow/bacil/BACILEngineOption.java
@@ -17,11 +17,11 @@ public final class BACILEngineOption {
     public static final String OPTION_ARRAY_SEPARATOR = ";";
 
     public static final String LIBRARY_PATH_NAME = "cil.libraryPath";
-    @Option(name = LIBRARY_PATH_NAME,
-            category = OptionCategory.USER,
-            stability = OptionStability.STABLE,
-            help = "A list of paths where BACIL will search for relative libraries. " +
-                    "Paths are delimited by a semicolon \'" + OPTION_ARRAY_SEPARATOR + "\'.")
+//    @Option(name = LIBRARY_PATH_NAME,
+//            category = OptionCategory.USER,
+//            stability = OptionStability.STABLE,
+//            help = "A list of paths where BACIL will search for relative libraries. " +
+//                    "Paths are delimited by a semicolon \'" + OPTION_ARRAY_SEPARATOR + "\'.")
     public static final OptionKey<String> LIBRARY_PATH = new OptionKey<>("");
 
     public static final String STUBBED_METHODS_NAME = "cil.stubMethods";

--- a/language/src/main/java/com/vztekoverflow/bacil/BACILLanguage.java
+++ b/language/src/main/java/com/vztekoverflow/bacil/BACILLanguage.java
@@ -17,8 +17,7 @@ import java.io.File;
 /**
  * The BACIL language class implementing TruffleLanguage.
  */
-@TruffleLanguage.Registration(id = BACILLanguage.ID, name = BACILLanguage.NAME, interactive = false, defaultMimeType = BACILLanguage.CIL_PE_MIME_TYPE,
-byteMimeTypes = {BACILLanguage.CIL_PE_MIME_TYPE})
+//@TruffleLanguage.Registration(id = BACILLanguage.ID, name = BACILLanguage.NAME, interactive = false, defaultMimeType = BACILLanguage.CIL_PE_MIME_TYPE, byteMimeTypes = {BACILLanguage.CIL_PE_MIME_TYPE})
 public class BACILLanguage extends TruffleLanguage<BACILContext> {
 
     public static final String ID = "cil";

--- a/language/src/main/java/com/vztekoverflow/cilostazol/CILOSTAZOLEngineOption.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/CILOSTAZOLEngineOption.java
@@ -3,6 +3,7 @@ package com.vztekoverflow.cilostazol;
 import com.oracle.truffle.api.Option;
 import com.oracle.truffle.api.TruffleLanguage;
 import org.graalvm.options.OptionCategory;
+import org.graalvm.options.OptionDescriptor;
 import org.graalvm.options.OptionKey;
 import org.graalvm.options.OptionStability;
 
@@ -18,16 +19,23 @@ public final class CILOSTAZOLEngineOption {
     public static final String LIBRARY_PATH_NAME = "cil.libraryPath";
 
     //TODO: undo comment when fully ported from BACIL -> now it causes regression
-//    @Option(name = LIBRARY_PATH_NAME,
-//            category = OptionCategory.USER,
-//            stability = OptionStability.STABLE,
-//            help = "A list of paths where BACIL will search for relative libraries. " +
-//                    "Paths are delimited by a semicolon \'" + OPTION_ARRAY_SEPARATOR + "\'.")
+    @Option(name = LIBRARY_PATH_NAME,
+            category = OptionCategory.USER,
+            stability = OptionStability.STABLE,
+            help = "A list of paths where CILOSTAZOL will search for relative libraries. " +
+                    "Paths are delimited by a semicolon \'" + OPTION_ARRAY_SEPARATOR + "\'.")
+
     public static final OptionKey<String> LIBRARY_PATH = new OptionKey<>("");
 
     public static Path[] getPolyglotOptionSearchPaths(TruffleLanguage.Env env) {
-        String libraryPathOption = env.getOptions().get(LIBRARY_PATH);
-        String[] libraryPaths = "".equals(libraryPathOption) ? new String[0] : libraryPathOption.split(OPTION_ARRAY_SEPARATOR);
-        return (Path[])Arrays.stream(libraryPaths).map(Paths::get).toArray();
+        if (env.getOptions().getDescriptors().get(LIBRARY_PATH_NAME) == null)
+            return new Path[]{Paths.get(".")};
+        else
+        {
+            OptionDescriptor desc = env.getOptions().getDescriptors().get(LIBRARY_PATH_NAME);
+            String libraryPathOption = env.getOptions().get((OptionKey<String>) desc.getKey());
+            String[] libraryPaths = "".equals(libraryPathOption) ? new String[0] : libraryPathOption.split(OPTION_ARRAY_SEPARATOR);
+            return (Path[])Arrays.stream(libraryPaths).map(Paths::get).toArray();
+        }
     }
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/CILOSTAZOLLanguage.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/CILOSTAZOLLanguage.java
@@ -1,5 +1,6 @@
 package com.vztekoverflow.cilostazol;
 
+import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.nodes.Node;
 import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
@@ -7,8 +8,7 @@ import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 /**
  * The BACIL language class implementing TruffleLanguage.
  */
-@TruffleLanguage.Registration(id = CILOSTAZOLLanguage.ID, name = CILOSTAZOLLanguage.NAME, interactive = false, defaultMimeType = CILOSTAZOLLanguage.CIL_PE_MIME_TYPE,
-byteMimeTypes = {CILOSTAZOLLanguage.CIL_PE_MIME_TYPE})
+@TruffleLanguage.Registration(id = CILOSTAZOLLanguage.ID, name = CILOSTAZOLLanguage.NAME, interactive = false, defaultMimeType = CILOSTAZOLLanguage.CIL_PE_MIME_TYPE, byteMimeTypes = {CILOSTAZOLLanguage.CIL_PE_MIME_TYPE})
 public class CILOSTAZOLLanguage extends TruffleLanguage<CILOSTAZOLContext> {
 
     public static final String ID = "cil";
@@ -24,6 +24,6 @@ public class CILOSTAZOLLanguage extends TruffleLanguage<CILOSTAZOLContext> {
 
     @Override
     protected CILOSTAZOLContext createContext(Env env) {
-        return null;
+        return new CILOSTAZOLContext(this, env);
     }
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/CILOSTAZOLContext.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/CILOSTAZOLContext.java
@@ -16,10 +16,10 @@ public class CILOSTAZOLContext {
     public CILOSTAZOLContext(CILOSTAZOLLanguage lang, TruffleLanguage.Env env) {
         _language = lang;
         _env = env;
-        _libraryPaths = (Path[]) Arrays.stream(CILOSTAZOLEngineOption.getPolyglotOptionSearchPaths(env)).filter(p -> {
+        _libraryPaths = Arrays.stream(CILOSTAZOLEngineOption.getPolyglotOptionSearchPaths(env)).filter(p -> {
             TruffleFile file = getEnv().getInternalTruffleFile(p.toString());
             return file.isDirectory();
-        }).distinct().toArray();
+        }).distinct().toArray(Path[]::new);
     }
 
     //For test propose only


### PR DESCRIPTION
TruffleReference se muze pouzivat jenom "uvnitr" launcheru a nejde to nejak lehce obejit...
Nyni alespon funguje pusteni launcheru ktery zaregistruje CILOSTAZOL. Aby to bylo mozne, je potreba predat path k CILOSTAZOLU pri spousteni
`-Dtruffle.class.path.append=E:\School\TeamProject\CILOSTAZOL-100mg\language\target\language-1.0-SNAPSHOT.jar`