### PR TITLE
Add type caching

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -16,8 +16,8 @@
   </component>
   <component name="JavacSettings">
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">
-      <module name="cil-parser" options="--add-exports org.graalvm.truffle/com.oracle.truffle.api=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.nodes=ALL-UNNAMED" />
-      <module name="language" options="--add-exports org.graalvm.truffle/com.oracle.truffle.api=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.nodes=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.staticobject=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.interop=ALL-UNNAMED" />
+      <module name="cil-parser" options="" />
+      <module name="language" options="--add-exports org.graalvm.truffle/com.oracle.truffle.api=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.nodes=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.staticobject=ALL-UNNAMED" />
       <module name="launcher" options="" />
       <module name="tests" options="" />
     </option>

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/cli/signature/ElementTypeFlag.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/cli/signature/ElementTypeFlag.java
@@ -1,0 +1,64 @@
+package com.vztekoverflow.cil.parser.cli.signature;
+
+import com.vztekoverflow.cil.parser.CILParserException;
+
+import java.util.Arrays;
+
+public class ElementTypeFlag {
+    public enum Flag
+    {
+        ELEMENT_TYPE_END(0x00),
+        ELEMENT_TYPE_VOID(0x01),
+        ELEMENT_TYPE_BOOLEAN(0x02),
+        ELEMENT_TYPE_CHAR(0x03),
+        ELEMENT_TYPE_I1(0x04),
+        ELEMENT_TYPE_U1(0x05),
+        ELEMENT_TYPE_I2(0x06),
+        ELEMENT_TYPE_U2(0x07),
+        ELEMENT_TYPE_I4(0x08),
+        ELEMENT_TYPE_U4(0x09),
+        ELEMENT_TYPE_I8(0x0a),
+        ELEMENT_TYPE_U8(0x0b),
+        ELEMENT_TYPE_R4(0x0c),
+        ELEMENT_TYPE_R8(0x0d),
+        ELEMENT_TYPE_STRING(0x0e),
+        ELEMENT_TYPE_PTR(0x0f),
+        ELEMENT_TYPE_BYREF(0x10),
+        ELEMENT_TYPE_VALUETYPE(0x11),
+        ELEMENT_TYPE_CLASS(0x12),
+        ELEMENT_TYPE_VAR(0x13),
+        ELEMENT_TYPE_ARRAY(0x14),
+        ELEMENT_TYPE_GENERICINST(0x15),
+        ELEMENT_TYPE_TYPEDBYREF(0x16),
+        ELEMENT_TYPE_I(0x18),
+        ELEMENT_TYPE_U(0x19),
+        ELEMENT_TYPE_FNPTR(0x1b),
+        ELEMENT_TYPE_OBJECT(0x1c),
+        ELEMENT_TYPE_SZARRAY(0x1d),
+        ELEMENT_TYPE_MVAR(0x1e);
+
+        public final int code;
+
+        Flag(int code)
+        {
+            this.code = code;
+        }
+    }
+
+    public ElementTypeFlag.Flag getFlag()
+    {
+        for (var el : Flag.values()){
+            if (el.code == _flag)
+                return el;
+        }
+
+        throw new CILParserException();
+    }
+
+    private final int _flag;
+
+    public ElementTypeFlag(int flags)
+    {
+        _flag = flags;
+    }
+}

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/cli/signature/TypeSig.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/cli/signature/TypeSig.java
@@ -49,7 +49,7 @@ public class TypeSig {
     public static TypeSig  createCLASS(CLITablePtr type) {return new TypeSig(ELEMENT_TYPE_CLASS, 0, type, null, null, null, null, null,  null);}
     public static TypeSig  createFNPTR(MethodDefSig methodDefSig) {throw new CILParserException(ParserBundle.message("cli.parser.exception.not.implemented"));}
     public static TypeSig  createFNPTR(MethodRefSig methodRefSig) {throw new CILParserException(ParserBundle.message("cli.parser.exception.not.implemented"));}
-    public static TypeSig  createGENERICINST(byte genericType, CLITablePtr type, TypeSig[] genParams) {return new TypeSig(genericType, 0, type, genParams, null, null, null, null,  null);}
+    public static TypeSig  createGENERICINST(byte genericType, CLITablePtr type, TypeSig[] genParams) {return new TypeSig(ELEMENT_TYPE_GENERICINST, 0, type, genParams, null, null, null, null,  null);}
     public static TypeSig  createMVAR(int idx) {return new TypeSig(ELEMENT_TYPE_MVAR, idx, null, null, null, null, null, null,  null);}
     public static TypeSig  createOBJECT() {return new TypeSig(ELEMENT_TYPE_OBJECT, 0, null, null, null, null, null, null,  null);}
     public static TypeSig  createPTR(CustomMod[] mods, TypeSig type) {return new TypeSig(ELEMENT_TYPE_PTR, 0, null, null, type, mods, null, null,  null);}
@@ -151,4 +151,7 @@ public class TypeSig {
     public CLITablePtr getCliTablePtr() {
         return cliTablePtr;
     }
+    public byte getElementType() {return  _typeType; }
+    public int getIndex() {return _idx;}
+    public TypeSig[] getTypeArgs() {return _genericParams; }
 }

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/cli/signature/TypeSpecSig.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/cli/signature/TypeSpecSig.java
@@ -1,0 +1,59 @@
+package com.vztekoverflow.cil.parser.cli.signature;
+
+import com.vztekoverflow.cil.parser.cli.CLIFile;
+import com.vztekoverflow.cil.parser.cli.table.CLITablePtr;
+
+public class TypeSpecSig {
+    private final ElementTypeFlag flag;
+    private final CustomMod[] mod;
+    private final TypeSig typeSig;
+    private final MethodDefSig mDefSig;
+    private final MethodRefSig mRefSig;
+    private final ArrayShapeSig arrayShapeSig;
+    private final int genArgCount;
+    private final TypeSig[] typeArgs;
+    private final CLITablePtr genType;
+
+    public ElementTypeFlag getFlag() { return flag; }
+    public TypeSig[] getTypeArgs() { return typeArgs; }
+    public CLITablePtr getGenType() {return genType;}
+
+    private TypeSpecSig(ElementTypeFlag flag, CustomMod[] mod, TypeSig typeSig, MethodDefSig mDefSig, MethodRefSig mRefSig, ArrayShapeSig arrayShapeSig, int genArgCount, TypeSig[] typeArgs, CLITablePtr genType) {
+        this.flag = flag;
+        this.mod = mod;
+        this.typeSig = typeSig;
+        this.mDefSig = mDefSig;
+        this.mRefSig = mRefSig;
+        this.arrayShapeSig = arrayShapeSig;
+        this.genArgCount = genArgCount;
+        this.typeArgs = typeArgs;
+        this.genType = genType;
+    }
+
+
+    public static TypeSpecSig read(SignatureReader reader, CLIFile file)
+    {
+        ElementTypeFlag flag = new ElementTypeFlag(reader.getUnsigned());
+        CustomMod[] mod = null;
+        TypeSig typeSig = null;
+        MethodDefSig mDefSig = null;
+        MethodRefSig mRefSig = null;
+        ArrayShapeSig arrayShapeSig = null;
+        int genArgCount = 0;
+        TypeSig[] typeArgs = null;
+        CLITablePtr genType = null;
+
+        if (flag.getFlag() == ElementTypeFlag.Flag.ELEMENT_TYPE_GENERICINST)
+        {
+            reader.getUnsigned();
+            genType = CLITablePtr.fromTypeDefOrRefOrSpecEncoded(reader.getUnsigned());
+            genArgCount = reader.getUnsigned();
+            typeArgs = new TypeSig[genArgCount];
+            for (int i = 0; i < typeArgs.length; i++) {
+                typeArgs[i] = TypeSig.read(reader, file);
+            }
+        }
+
+        return new TypeSpecSig(flag, mod, typeSig, mDefSig, mRefSig, arrayShapeSig, genArgCount, typeArgs, genType);
+    }
+}

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/assembly/Assembly.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/assembly/Assembly.java
@@ -5,6 +5,7 @@ import com.vztekoverflow.cil.parser.cli.AssemblyIdentity;
 import com.vztekoverflow.cil.parser.cli.CLIFile;
 import com.vztekoverflow.cil.parser.cli.table.generated.CLITableConstants;
 import com.vztekoverflow.cilostazol.CILOSTAZOLBundle;
+import com.vztekoverflow.cilostazol.runtime.typesystem.appdomain.AppDomain;
 import com.vztekoverflow.cilostazol.runtime.typesystem.appdomain.IAppDomain;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.CLIComponent;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.IComponent;
@@ -58,7 +59,7 @@ public class Assembly implements IAssembly {
         appDomain = null;
     }
 
-    public static IAssembly parse(Source dllSource) {
+    public static IAssembly parse(IAppDomain domain, Source dllSource) {
         CLIFile file = CLIFile.parse(dllSource.getName(), dllSource.getPath(), dllSource.getBytes());
 
         if (file.getTablesHeader().getRowCount(CLITableConstants.CLI_TABLE_MODULE) != 1)
@@ -68,6 +69,7 @@ public class Assembly implements IAssembly {
             throw new CILParserException(CILOSTAZOLBundle.message("cilostazol.exception.multimoduleAssembly"));
 
         Assembly assembly = new Assembly(file, new IComponent[1]);
+        domain.loadAssembly(assembly);
         assembly.components[0] = CLIComponent.parse(file, assembly);
 
         return assembly;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/field/Field.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/field/Field.java
@@ -56,7 +56,7 @@ public class Field extends StaticProperty implements IField {
 
     @Override
     public IField substitute(ISubstitution<IType> substitution) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return new Field(name, substitution.substitute(type), isStatic, isInitOnly, isLiteral, isNotSerialized, isSpecialName, flags, definingFile);
     }
 
     @Override

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/field/factory/FieldFactory.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/field/factory/FieldFactory.java
@@ -11,12 +11,12 @@ import com.vztekoverflow.cilostazol.runtime.typesystem.type.IType;
 import com.vztekoverflow.cilostazol.runtime.typesystem.type.factory.TypeFactory;
 
 public final class FieldFactory {
-    public static IField create(CILOSTAZOLContext context, CLIFieldTableRow fieldRow, CLIComponent component) {
+    public static IField create(CILOSTAZOLContext context, CLIFieldTableRow fieldRow, IType[] mvars, IType[] vars, CLIComponent component) {
         final String name = component.getNameFrom(fieldRow);
         final var signature = fieldRow.getSignatureHeapPtr().read(component.getDefiningFile().getBlobHeap());
 
         final FieldSig fieldSig = FieldSig.parse(new SignatureReader(signature));
-        final IType type = TypeFactory.create(context, fieldSig.getType(), null, null, component);
+        final IType type = TypeFactory.create(context, fieldSig.getType(), mvars, vars, component);
         boolean isStatic = (fieldRow.getFlags() & 0x0010) != 0;
         boolean isInitOnly = (fieldRow.getFlags() & 0x0010) != 0;
         boolean isLiteral = (fieldRow.getFlags() & 0x0040) != 0;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/generic/Substitution.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/generic/Substitution.java
@@ -12,8 +12,16 @@ public class Substitution<TItem> implements ISubstitution<TItem>{
         _map = map;
     }
 
+    public Substitution(TItem[] from, TItem[] to)
+    {
+        _map = new HashMap<TItem, TItem>(from.length);
+        for (int i = 0; i < from.length; i++) {
+            _map.put(from[i], to[i]);
+        }
+    }
+
     @Override
     public TItem substitute(TItem type) {
-        return _map.getOrDefault(type, null);
+        return _map.getOrDefault(type, type);
     }
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/NonGenericMethod.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/NonGenericMethod.java
@@ -62,7 +62,7 @@ public class NonGenericMethod extends MethodBase{
 
     @Override
     public IMethod substitute(ISubstitution<IType> substitution) {
-        throw new TypeSystemException(CILOSTAZOLBundle.message("cilostazol.exception.invalidOperation"));
+        return new SubstitutedGenericMethod(this, getDefinition(), substitution);
     }
 
     @Override

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/SubstitutedGenericMethod.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/SubstitutedGenericMethod.java
@@ -8,6 +8,7 @@ import com.vztekoverflow.cilostazol.nodes.CILOSTAZOLRootNode;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.IComponent;
 import com.vztekoverflow.cilostazol.runtime.typesystem.generic.ISubstitution;
 import com.vztekoverflow.cilostazol.runtime.typesystem.generic.ITypeParameter;
+import com.vztekoverflow.cilostazol.runtime.typesystem.generic.TypeParameter;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.exceptionhandler.IExceptionHandler;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.flags.MethodFlags;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.flags.MethodHeaderFlags;
@@ -16,6 +17,8 @@ import com.vztekoverflow.cilostazol.runtime.typesystem.method.local.ILocal;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.parameter.IParameter;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.returnType.IReturnType;
 import com.vztekoverflow.cilostazol.runtime.typesystem.type.IType;
+
+import java.util.Arrays;
 
 public class SubstitutedGenericMethod implements IMethod, ICILBasedMethod {
     protected final IMethod _definition;
@@ -38,22 +41,22 @@ public class SubstitutedGenericMethod implements IMethod, ICILBasedMethod {
 
     @Override
     public IParameter[] getParameters() {
-        throw new NotImplementedException();
+        return Arrays.stream(_constructedFrom.getParameters()).map(x -> x.substitute(_substitution)).toArray(IParameter[]::new);
     }
 
     @Override
     public ILocal[] getLocals() {
-        throw new NotImplementedException();
+        return Arrays.stream(_constructedFrom.getLocals()).map(x -> x.substitute(_substitution)).toArray(ILocal[]::new);
     }
 
     @Override
     public ITypeParameter[] getTypeParameters() {
-        throw new NotImplementedException();
+        return Arrays.stream(_constructedFrom.getTypeParameters()).map(x -> x.substitute(_substitution)).toArray(ITypeParameter[]::new);
     }
 
     @Override
     public IReturnType getReturnType() {
-        throw new NotImplementedException();
+        return _constructedFrom.getReturnType().substitute(_substitution);
     }
 
     @Override
@@ -78,7 +81,7 @@ public class SubstitutedGenericMethod implements IMethod, ICILBasedMethod {
 
     @Override
     public IExceptionHandler[] getExceptionHandlers() {
-        throw new NotImplementedException();
+        return Arrays.stream(_constructedFrom.getExceptionHandlers()).map(x -> x.substitute(_substitution)).toArray(IExceptionHandler[]::new);
     }
 
     @Override

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/exceptionhandler/ExceptionHandler.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/exceptionhandler/ExceptionHandler.java
@@ -43,7 +43,7 @@ public class ExceptionHandler implements IExceptionHandler {
 
     @Override
     public IType getHandlingException() {
-        return null;
+        return _handlerException;
     }
 
     @Override
@@ -53,7 +53,7 @@ public class ExceptionHandler implements IExceptionHandler {
 
     @Override
     public IExceptionHandler substitute(ISubstitution<IType> substitution) {
-        throw new NotImplementedException();
+        return new ExceptionHandler(_tryOffset, _tryLength, _handlerOffset, _handlerLength, _handlerException.substitute(substitution), _flags);
     }
 
     @Override

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/local/Local.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/local/Local.java
@@ -39,7 +39,7 @@ public class Local implements ILocal{
 
     @Override
     public ILocal substitute(ISubstitution<IType> substitution) {
-        throw new NotImplementedException();
+        return new Local(_pinned, _byRef, _type.substitute(substitution));
     }
 
     @Override

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/parameter/IParameter.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/parameter/IParameter.java
@@ -8,4 +8,5 @@ public interface IParameter extends ISubstitutable<IParameter, IType> {
     ParamFlags getFlags();
     int getIndex();
     public String getName();
+    IType getType();
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/parameter/Parameter.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/parameter/Parameter.java
@@ -22,7 +22,7 @@ public class Parameter implements IParameter {
     //region IParameter
     @Override
     public IParameter substitute(ISubstitution<IType> substitution) {
-        throw new NotImplementedException();
+        return new Parameter(_isByRef, _type.substitute(substitution),_name, _idx, _flags );
     }
 
     @Override

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/parameter/Parameter.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/parameter/Parameter.java
@@ -54,5 +54,10 @@ public class Parameter implements IParameter {
     public String getName() {
         return _name;
     }
+
+    @Override
+    public IType getType() {
+        return _type;
+    }
     //endregion
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/returnType/ReturnType.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/returnType/ReturnType.java
@@ -27,7 +27,7 @@ public class ReturnType implements IReturnType {
 
     @Override
     public IReturnType substitute(ISubstitution<IType> substitution) {
-        throw new NotImplementedException();
+        return new ReturnType(_byRef, _type.substitute(substitution));
     }
 
     @Override

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/TypeBase.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/TypeBase.java
@@ -263,7 +263,7 @@ public abstract class TypeBase<T extends CLITableRow<T>> extends CLIType impleme
 
         var fields = new ArrayList<IField>();
         while (fieldRow.getRowNo() < fieldListEndPtr.getRowNo() && fieldRow.hasNext()) {
-            var field = FieldFactory.create(getContext(), fieldRow, _definingComponent);
+            var field = FieldFactory.create(getContext(), fieldRow, new IType[0], getTypeParameters(), _definingComponent);
             fields.add(field);
             fieldRow = fieldRow.next();
         }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/TypeBase.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/TypeBase.java
@@ -263,7 +263,7 @@ public abstract class TypeBase<T extends CLITableRow<T>> extends CLIType impleme
 
         var fields = new ArrayList<IField>();
         while (fieldRow.getRowNo() < fieldListEndPtr.getRowNo() && fieldRow.hasNext()) {
-            var field = FieldFactory.create(getContext(), fieldRow, new IType[0], getTypeParameters(), _definingComponent);
+            var field = FieldFactory.create(getContext(), fieldRow, new IType[0], (this instanceof NonGenericType) ? new IType[0] : getTypeParameters(), _definingComponent);
             fields.add(field);
             fieldRow = fieldRow.next();
         }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/factory/FactoryUtils.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/factory/FactoryUtils.java
@@ -71,15 +71,15 @@ public final class FactoryUtils {
         };
     }
 
-    static IType getDirectBaseClass(CILOSTAZOLContext context, CLITypeDefTableRow typeDefRow, CLIComponent component) {
+    static IType getDirectBaseClass(CILOSTAZOLContext context, CLITypeDefTableRow typeDefRow, IType[] mvars, IType[] vars,CLIComponent component) {
         CLITablePtr tablePtr = typeDefRow.getExtendsTablePtr();
         if (tablePtr.isEmpty()) return null;
 
         IType baseClass;
         switch (tablePtr.getTableId()) {
             case CLITableConstants.CLI_TABLE_TYPE_DEF -> baseClass = component.getLocalType(context, tablePtr);
-            case CLITableConstants.CLI_TABLE_TYPE_REF -> baseClass = null; //TODO: implement case for ref table
-            case CLITableConstants.CLI_TABLE_TYPE_SPEC -> baseClass = null; //TODO: implement case for spec table
+            case CLITableConstants.CLI_TABLE_TYPE_REF -> baseClass = TypeFactory.create(context, component.getDefiningFile().getTableHeads().getTypeRefTableHead().skip(tablePtr), component);
+            case CLITableConstants.CLI_TABLE_TYPE_SPEC -> baseClass = TypeFactory.create(context, component.getDefiningFile().getTableHeads().getTypeSpecTableHead().skip(tablePtr), mvars, vars, component);
             default -> throw new NotImplementedException();
         }
         return baseClass;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/factory/TypeFactory.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/factory/TypeFactory.java
@@ -22,7 +22,7 @@ public final class TypeFactory {
     public static IType create(CILOSTAZOLContext context, CLITablePtr ptr, IType[] mvars, IType[] vars, CLIComponent component) {
         return switch (ptr.getTableId()) {
             case CLITableConstants.CLI_TABLE_TYPE_DEF ->
-                    TypeFactory.create(context, component.getDefiningFile().getTableHeads().getTypeDefTableHead().skip(ptr), component);
+                    component.getLocalType(context, ptr);
             case CLITableConstants.CLI_TABLE_TYPE_REF ->
                     TypeFactory.create(context, component.getDefiningFile().getTableHeads().getTypeRefTableHead().skip(ptr), component);
             case CLITableConstants.CLI_TABLE_TYPE_SPEC ->

--- a/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/FieldParsingTests.java
+++ b/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/FieldParsingTests.java
@@ -23,8 +23,7 @@ public class FieldParsingTests extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "Class");
 
         assertEquals(9, type.getFields().length);
@@ -38,8 +37,7 @@ public class FieldParsingTests extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "Class");
 
         assertTrue(Arrays.stream(type.getFields()).anyMatch(f -> f.getName().equals("fieldClass2")));
@@ -55,8 +53,7 @@ public class FieldParsingTests extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "Class");
 
         assertFalse(Arrays.stream(type.getFields()).filter(f -> f.getName().equals("fieldClass2")).findFirst().get().isStatic());
@@ -71,8 +68,7 @@ public class FieldParsingTests extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "Class");
 
         assertTrue(Arrays.stream(type.getFields()).anyMatch(f -> f.getName().equals("fieldPrivate")));
@@ -108,8 +104,7 @@ public class FieldParsingTests extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "Class");
 
         assertTrue(Arrays.stream(type.getFields()).anyMatch(f -> f.getName().equals("fieldSelf")));

--- a/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/MethodMetadataTests.java
+++ b/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/MethodMetadataTests.java
@@ -33,7 +33,7 @@ public class MethodMetadataTests  extends TestBase {
         Source source = getSourceFromProject(projectName);
 
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
+        IAssembly assembly = Assembly.parse(domain, source);
         domain.loadAssembly(assembly);
         return assembly;
     }

--- a/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/MethodMetadataTests.java
+++ b/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/MethodMetadataTests.java
@@ -153,19 +153,19 @@ public class MethodMetadataTests  extends TestBase {
         IMethod[] mFoo = getMethod(type, "Foo");
         assertEquals(1, mFoo.length);
         assertFalse(mFoo[0].getReturnType().isByRef());
-        //TODO: assert return type
+        assertNull(mFoo[0].getReturnType().getType());
 
         //public ReturnT Foo1()
         IMethod[] mFoo1 = getMethod(type, "Foo1");
         assertEquals(1, mFoo1.length);
         assertFalse(mFoo1[0].getReturnType().isByRef());
-        //TODO: assert return type
+        assertEquals(assembly.getLocalType("MethodMetadataTest", "ReturnT"), mFoo1[0].getReturnType().getType());
 
         //public ref ReturnT Foo2()
         IMethod[] mFoo2 = getMethod(type, "Foo2");
         assertEquals(1, mFoo2.length);
         assertTrue(mFoo2[0].getReturnType().isByRef());
-        //TODO: assert return type
+        assertEquals(assembly.getLocalType("MethodMetadataTest", "ReturnT"), mFoo1[0].getReturnType().getType());
     }
 
     public void testMethod_Parameters() throws Exception
@@ -191,7 +191,7 @@ public class MethodMetadataTests  extends TestBase {
         assertEquals("p1", mFoo[1].getParameters()[0].getName());
         assertFalse(mFoo[1].getParameters()[0].getFlags().hasFlag(ParamFlags.Flag.HAS_DEFAULT));
         assertFalse(mFoo[1].getParameters()[0].getFlags().hasFlag(ParamFlags.Flag.OPTIONAL));
-        //TODO: assert parameter type
+        assertEquals(assembly.getLocalType("MethodMetadataTest", "Param1"), mFoo[1].getParameters()[0].getType());
 
         //public static void Foo1(Param1 p1) {}
         IMethod[] mFoo1 = getMethod(type, "Foo1");
@@ -208,7 +208,7 @@ public class MethodMetadataTests  extends TestBase {
         assertEquals(2, mFoo3[0].getParameters()[1].getIndex());
         assertEquals("p1", mFoo3[0].getParameters()[0].getName());
         assertEquals("ps", mFoo3[0].getParameters()[1].getName());
-        //TODO: assert parameter types
+        //TODO: assert object type
 
         //public static void Foo4(ref Param1 p1, out Param1 p2, in Param1 p3)
         IMethod[] mFoo4 = getMethod(type, "Foo4");
@@ -224,7 +224,9 @@ public class MethodMetadataTests  extends TestBase {
         assertTrue(mFoo4[0].getParameters()[0].isByRef());
         assertTrue(mFoo4[0].getParameters()[1].getFlags().hasFlag(ParamFlags.Flag.OUT));
         assertTrue(mFoo4[0].getParameters()[2].getFlags().hasFlag(ParamFlags.Flag.IN));
-        //TODO: assert parameter types
+        assertEquals(assembly.getLocalType("MethodMetadataTest", "Param1"), mFoo4[0].getParameters()[0].getType());
+        assertEquals(assembly.getLocalType("MethodMetadataTest", "Param1"), mFoo4[0].getParameters()[1].getType());
+        assertEquals(assembly.getLocalType("MethodMetadataTest", "Param1"), mFoo4[0].getParameters()[2].getType());
 
 
         //public void Foo5(Param1 p1 = null) {}
@@ -234,7 +236,7 @@ public class MethodMetadataTests  extends TestBase {
         assertEquals("p1", mFoo5[0].getParameters()[0].getName());
         assertTrue(mFoo5[0].getParameters()[0].getFlags().hasFlag(ParamFlags.Flag.OPTIONAL));
         assertTrue(mFoo5[0].getParameters()[0].getFlags().hasFlag(ParamFlags.Flag.HAS_DEFAULT));
-        //TODO: assert parameter type
+        assertEquals(assembly.getLocalType("MethodMetadataTest", "Param1"), mFoo5[0].getParameters()[0].getType());
     }
 
     public void testMethod_Extensions() throws Exception

--- a/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/MethodParsingTests.java
+++ b/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/MethodParsingTests.java
@@ -31,8 +31,7 @@ public class MethodParsingTests extends TestBase {
 
 
         final IAppDomain domain = new AppDomain(ctx);
-        final IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        final IAssembly assembly = Assembly.parse(domain, source);
 
         final CLIComponent component = (CLIComponent) assembly.getComponents()[0];
         //Classes
@@ -75,8 +74,7 @@ public class MethodParsingTests extends TestBase {
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         Source source = getSourceFromProject(projectName);
         final IAppDomain domain = new AppDomain(ctx);
-        final IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        final IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "A");
 
 

--- a/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/SubstitutionTest.java
+++ b/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/SubstitutionTest.java
@@ -1,0 +1,201 @@
+package com.vztekoverflow.cilostazol.runtime.typesystem;
+
+import com.vztekoverflow.cilostazol.CILOSTAZOLLanguage;
+import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
+import com.vztekoverflow.cilostazol.runtime.typesystem.appdomain.AppDomain;
+import com.vztekoverflow.cilostazol.runtime.typesystem.appdomain.IAppDomain;
+import com.vztekoverflow.cilostazol.runtime.typesystem.assembly.Assembly;
+import com.vztekoverflow.cilostazol.runtime.typesystem.assembly.IAssembly;
+import com.vztekoverflow.cilostazol.runtime.typesystem.generic.Substitution;
+import com.vztekoverflow.cilostazol.runtime.typesystem.method.IMethod;
+import com.vztekoverflow.cilostazol.runtime.typesystem.type.IType;
+import org.graalvm.polyglot.Source;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+
+public class SubstitutionTest  extends TestBase  {
+    private IAssembly getAssembly() throws Exception
+    {
+        final String projectName = "SubstitutionTest";
+
+        final CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
+        CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
+        Source source = getSourceFromProject(projectName);
+
+        IAppDomain domain = new AppDomain(ctx);
+        IAssembly assembly = Assembly.parse(domain, source);
+        return assembly;
+    }
+
+    private IType getType(IAssembly assembly, String namespace, String klass)
+    {
+        return assembly.getLocalType(namespace, klass);
+    }
+
+    public void testSubTypeParameter() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        //class Accessibility
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeG1 = getType(assembly, "SubstitutionTest", "G1a`1");
+
+        Substitution<IType> substitution1 =
+            new Substitution<>(
+                new HashMap<IType, IType>() {{
+                    put(typeG1.getTypeParameters()[0], typeA1);
+                }}
+            );
+
+        IType substitutedG1 = typeG1.substitute(substitution1);
+        assertEquals(typeA1, substitutedG1.getTypeParameters()[0]);
+    }
+
+    public void testSubInheritance() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeG1 = getType(assembly, "SubstitutionTest", "G1b`1");
+
+        Substitution<IType> substitution1 =
+                new Substitution<>(
+                        new HashMap<IType, IType>() {{
+                            put(typeG1.getTypeParameters()[0], typeA1);
+                        }}
+                );
+
+        IType substitutedG1 = typeG1.substitute(substitution1);
+        IType baseClass = substitutedG1.getDirectBaseClass();
+        assertEquals(baseClass.getTypeParameters()[0], typeA1);
+    }
+
+    public void testSubFields() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeG1 = getType(assembly, "SubstitutionTest", "G1c`1");
+
+        Substitution<IType> substitution1 =
+                new Substitution<>(
+                        new HashMap<IType, IType>() {{
+                            put(typeG1.getTypeParameters()[0], typeA1);
+                        }}
+                );
+
+        IType substitutedG1 = typeG1.substitute(substitution1);
+        IType field = substitutedG1.getFields()[0].getType();
+        assertEquals(typeA1, field);
+    }
+    public void testSubClassMethod() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeG1 = getType(assembly, "SubstitutionTest", "G1d`1");
+
+        Substitution<IType> substitution1 =
+                new Substitution<>(
+                        new HashMap<IType, IType>() {{
+                            put(typeG1.getTypeParameters()[0], typeA1);
+                        }}
+                );
+
+        IType substitutedG1 = typeG1.substitute(substitution1);
+        IMethod method = substitutedG1.getMethods()[0];
+        assertEquals(typeA1, method.getParameters()[0].getType());
+    }
+
+    public void testNestedInheritance() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeG1 = getType(assembly, "SubstitutionTest", "G1e`1");
+
+        Substitution<IType> substitution1 =
+                new Substitution<>(
+                        new HashMap<IType, IType>() {{
+                            put(typeG1.getTypeParameters()[0], typeA1);
+                        }}
+                );
+
+        IType substitutedG1 = typeG1.substitute(substitution1);
+        IType typeParam = substitutedG1.getDirectBaseClass().getTypeParameters()[0].getTypeParameters()[0];
+        assertEquals(typeA1, typeParam);
+    }
+
+    public void testMethodRetParam() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeMethod = getType(assembly, "SubstitutionTest", "Methods");
+        IMethod method = typeMethod.getMethods()[2];
+
+        Substitution<IType> substitution1 =
+        new Substitution<>(
+                new HashMap<IType, IType>() {{
+                    put(method.getTypeParameters()[0], typeA1);
+                }}
+        );
+
+        IMethod substitutedMethod = method.substitute(substitution1);
+        assertEquals(typeA1, substitutedMethod.getReturnType().getType());
+    }
+
+    public void testMethodSubLocals() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeMethod = getType(assembly, "SubstitutionTest", "Methods");
+        IMethod method = typeMethod.getMethods()[3];
+
+        Substitution<IType> substitution1 =
+                new Substitution<>(
+                        new HashMap<IType, IType>() {{
+                            put(method.getTypeParameters()[0], typeA1);
+                        }}
+                );
+
+        IMethod substitutedMethod = method.substitute(substitution1);
+        assertEquals(typeA1, substitutedMethod.getLocals()[0].getType());
+    }
+
+    public void testMethodSubTryBlock() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeMethod = getType(assembly, "SubstitutionTest", "Methods");
+        IMethod method = typeMethod.getMethods()[4];
+
+        Substitution<IType> substitution1 =
+                new Substitution<>(
+                        new HashMap<IType, IType>() {{
+                            put(method.getTypeParameters()[0], typeA1);
+                        }}
+                );
+
+        IMethod substitutedMethod = method.substitute(substitution1);
+        assertEquals(typeA1, substitutedMethod.getExceptionHandlers()[0].getHandlingException());
+    }
+
+    public void testMethodSubContraint() throws Exception
+    {
+        IAssembly assembly = getAssembly();
+        IType typeA1 = getType(assembly, "SubstitutionTest", "A1");
+        IType typeMethod = getType(assembly, "SubstitutionTest", "Methods");
+        IMethod method = typeMethod.getMethods()[5];
+
+        Substitution<IType> substitution1 =
+                new Substitution<>(
+                        new HashMap<IType, IType>() {{
+                            put(method.getTypeParameters()[0], typeA1);
+                        }}
+                );
+
+        IMethod substitutedMethod = method.substitute(substitution1);
+        //assertEquals(typeA1, substitutedMethod.getTypeParameters()[0]);
+    }
+
+    public void testSubInterfaceImpl() throws Exception
+    {
+
+    }
+}

--- a/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/TypeParsingTest.java
+++ b/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/TypeParsingTest.java
@@ -28,8 +28,7 @@ public class TypeParsingTest extends TestBase {
         Source source = getSourceFromProject(projectName);
 
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
 
         assertFalse(domain.getAssemblies().length == 0);
     }
@@ -46,8 +45,7 @@ public class TypeParsingTest extends TestBase {
 
 
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
 
         IType type = assembly.getLocalType("FindLocalType", "Class");
 
@@ -62,8 +60,7 @@ public class TypeParsingTest extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "Class");
 
 
@@ -81,8 +78,7 @@ public class TypeParsingTest extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "Class");
 
 
@@ -111,8 +107,7 @@ public class TypeParsingTest extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType type = assembly.getLocalType(projectName, "Class`1");
 
 
@@ -127,8 +122,7 @@ public class TypeParsingTest extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(source);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, source);
         IType localType = assembly.getLocalType(projectName, "Class1");
 
         assertEquals(2, localType.getFields().length);
@@ -144,12 +138,10 @@ public class TypeParsingTest extends TestBase {
         CILOSTAZOLLanguage lang = new CILOSTAZOLLanguage();
         CILOSTAZOLContext ctx = new CILOSTAZOLContext(lang, new Path[0]);
         IAppDomain domain = new AppDomain(ctx);
-        IAssembly assembly = Assembly.parse(sources[0]);
-        domain.loadAssembly(assembly);
+        IAssembly assembly = Assembly.parse(domain, sources[0]);
         //foreign assembly
         //TODO: this should be done by assembly loader?
-        IAssembly otherAssembly = Assembly.parse(sources[1]);
-        domain.loadAssembly(otherAssembly);
+        IAssembly otherAssembly = Assembly.parse(domain, sources[1]);
 
         IType localType = assembly.getLocalType(projectName, "Class1");
 

--- a/language/src/test/resources/TypeParsingTestTargets/SubstitutionTest/Class.cs
+++ b/language/src/test/resources/TypeParsingTestTargets/SubstitutionTest/Class.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace SubstitutionTest;
+
+class A1 {}
+
+class G1a<T1> {}
+
+class G1b<T1> : G1a<T1> {}
+
+class G1c<T1>
+{
+    public T1 field1;
+}
+
+class G1d<T1>
+{
+    public void Foo(T1 a) {}
+}
+
+class G1e<T1> : G1d<G1d<T1>> {}
+
+class Methods
+{
+    public void Bar() {}
+    public void Foo<T1>(T1 p1) {}
+    public T1 Foo1<T1>() {throw new NotImplementedException();}
+    public void Foo2<T1>(T1 p1)
+    {
+        T1 a = p1;
+        Foo(a);
+        Foo(a);
+        Foo(p1);
+    }
+    public void Foo3<T1>() where T1 : Exception
+    {
+        try
+        {
+            Bar();
+        }
+        catch (T1 ex)
+        {
+            Bar();
+        }
+    }
+
+    public void Foo4<T1>() where T1 : G1a<T1> {}
+}
+
+interface II1<T1> {}
+interface II2<T1> {}
+
+public class G2a<T1, T2> : II1<T1>, II2<T2> {}

--- a/language/src/test/resources/TypeParsingTestTargets/SubstitutionTest/SubstitutionTest.csproj
+++ b/language/src/test/resources/TypeParsingTestTargets/SubstitutionTest/SubstitutionTest.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Pridal jsem jen pole ITypes kam nahraju vsechny typy definovane v komponente pri vytvareni komponenty. Vzhledem k tomu ze IType vsechno vraci lazy, tak by to nemelo byt nejak narocne. Taky pri parsovani Assembly rovnou `parse` vyzaduje AppDomain kam assembly nahraje. Diky tomu muzeme pouzivat context uz pri vytvareni Assembly.