### PR TITLE
Expose CILOSTAZOLContext using interfaces

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -16,8 +16,8 @@
   </component>
   <component name="JavacSettings">
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">
-      <module name="cil-parser" options="" />
-      <module name="language" options="--add-exports org.graalvm.truffle/com.oracle.truffle.api=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.nodes=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.staticobject=ALL-UNNAMED" />
+      <module name="cil-parser" options="--add-exports org.graalvm.truffle/com.oracle.truffle.api=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.nodes=ALL-UNNAMED" />
+      <module name="language" options="--add-exports org.graalvm.truffle/com.oracle.truffle.api=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.nodes=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.staticobject=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.interop=ALL-UNNAMED --add-exports org.graalvm.truffle/com.oracle.truffle.api.frame=ALL-UNNAMED" />
       <module name="launcher" options="" />
       <module name="tests" options="" />
     </option>

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILOSTAZOLRootNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILOSTAZOLRootNode.java
@@ -8,7 +8,7 @@ import com.vztekoverflow.cilostazol.runtime.typesystem.method.IMethod;
 public class CILOSTAZOLRootNode extends RootNode {
     protected final CILMethodNode _node;
     private CILOSTAZOLRootNode(FrameDescriptor descriptor, CILMethodNode node) {
-        super(node.getMethod().getDefiningComponent().getDefiningAssembly().getAppDomain().getContext().getLanguage(), descriptor);
+        super(node.getMethod().getDefiningComponent().getLanguage(), descriptor);
         _node = node;
     }
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/appdomain/AppDomain.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/appdomain/AppDomain.java
@@ -1,17 +1,17 @@
 package com.vztekoverflow.cilostazol.runtime.typesystem.appdomain;
 
 import com.vztekoverflow.cil.parser.cli.AssemblyIdentity;
+import com.vztekoverflow.cilostazol.context.ContextAccessImpl;
 import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.typesystem.assembly.IAssembly;
 
 import java.util.ArrayList;
 
-public class AppDomain implements IAppDomain {
+public class AppDomain extends ContextAccessImpl implements IAppDomain {
     private final ArrayList<IAssembly> _assemblies;
-    private final CILOSTAZOLContext _ctx;
 
     public AppDomain(CILOSTAZOLContext ctx) {
-        _ctx = ctx;
+        super(ctx);
         _assemblies = new ArrayList<>();
     }
 
@@ -37,11 +37,6 @@ public class AppDomain implements IAppDomain {
     public void loadAssembly(IAssembly assembly) {
         assembly.setAppDomain(this);
         _assemblies.add(assembly);
-    }
-
-    @Override
-    public CILOSTAZOLContext getContext() {
-        return _ctx;
     }
     //endregion
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/appdomain/IAppDomain.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/appdomain/IAppDomain.java
@@ -1,12 +1,13 @@
 package com.vztekoverflow.cilostazol.runtime.typesystem.appdomain;
 
 import com.vztekoverflow.cil.parser.cli.AssemblyIdentity;
+import com.vztekoverflow.cilostazol.context.ContextAccess;
 import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.typesystem.assembly.IAssembly;
 
-public interface IAppDomain {
-    public IAssembly[] getAssemblies();
-    public IAssembly getAssembly(AssemblyIdentity identity);
-    public void loadAssembly(IAssembly assembly);
-    public CILOSTAZOLContext getContext();
+public interface IAppDomain extends ContextAccess {
+    IAssembly[] getAssemblies();
+    IAssembly getAssembly(AssemblyIdentity identity);
+    void loadAssembly(IAssembly assembly);
+    CILOSTAZOLContext getContext();
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/assembly/Assembly.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/assembly/Assembly.java
@@ -5,6 +5,7 @@ import com.vztekoverflow.cil.parser.cli.AssemblyIdentity;
 import com.vztekoverflow.cil.parser.cli.CLIFile;
 import com.vztekoverflow.cil.parser.cli.table.generated.CLITableConstants;
 import com.vztekoverflow.cilostazol.CILOSTAZOLBundle;
+import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.typesystem.appdomain.AppDomain;
 import com.vztekoverflow.cilostazol.runtime.typesystem.appdomain.IAppDomain;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.CLIComponent;
@@ -31,7 +32,7 @@ public class Assembly implements IAssembly {
     public IType getLocalType(String namespace, String name) {
         IType result = null;
         for (int i = 0; i < components.length && result == null; i++) {
-            result = components[i].getLocalType(appDomain.getContext(), namespace, name);
+            result = components[i].getLocalType(namespace, name);
         }
 
         return result;
@@ -51,6 +52,15 @@ public class Assembly implements IAssembly {
     public IAppDomain getAppDomain() {
         return appDomain;
     }
+
+    @Override
+    public CILOSTAZOLContext getContext() {
+        if (appDomain == null)
+            throw new CILParserException(CILOSTAZOLBundle.message("cilostazol.exception.noAppDomain"));
+
+        return appDomain.getContext();
+    }
+
     //endregion
 
     private Assembly(CLIFile file, IComponent[] components) {

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/assembly/IAssembly.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/assembly/IAssembly.java
@@ -2,17 +2,17 @@ package com.vztekoverflow.cilostazol.runtime.typesystem.assembly;
 
 import com.vztekoverflow.cil.parser.cli.AssemblyIdentity;
 import com.vztekoverflow.cil.parser.cli.CLIFile;
+import com.vztekoverflow.cilostazol.context.ContextAccess;
 import com.vztekoverflow.cilostazol.runtime.typesystem.appdomain.IAppDomain;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.IComponent;
 import com.vztekoverflow.cilostazol.runtime.typesystem.type.IType;
 
-public interface IAssembly {
+public interface IAssembly extends ContextAccess {
     //TODO: CLIFIle in IAssembly ... get rid of it, or abandon IAssembly completely?
-    public CLIFile getDefiningFile();
-    public IComponent[] getComponents();
-    public AssemblyIdentity getIdentity();
-    public void setAppDomain(IAppDomain appdomain);
-    public IAppDomain getAppDomain();
-
-    public IType getLocalType(String namespace, String name);
+    CLIFile getDefiningFile();
+    IComponent[] getComponents();
+    AssemblyIdentity getIdentity();
+    void setAppDomain(IAppDomain appdomain);
+    IAppDomain getAppDomain();
+    IType getLocalType(String namespace, String name);
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/component/CLIComponent.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/component/CLIComponent.java
@@ -49,7 +49,7 @@ public class CLIComponent implements IComponent {
     }
 
     @Override
-    public IType getLocalType(CILOSTAZOLContext context, String namespace, String name) {
+    public IType getLocalType(String namespace, String name) {
         //printAllTypesFile();
 
         //Check typeDefs
@@ -77,7 +77,7 @@ public class CLIComponent implements IComponent {
     }
 
     @Override
-    public IType getLocalType(CILOSTAZOLContext context, CLITablePtr tablePtr) {
+    public IType getLocalType(CLITablePtr tablePtr) {
         var typeDefTableRow = getTableHeads().getTypeDefTableHead().skip(tablePtr);
         return typeCache[typeDefTableRow.getPtr().getRowNo()-1];
     }
@@ -119,6 +119,10 @@ public class CLIComponent implements IComponent {
         return _cliFile.getTableHeads();
     }
 
+    @Override
+    public CILOSTAZOLContext getContext() {
+        return _definingAssembly.getContext();
+    }
     //endregion
 
     private CLIComponent(CLIFile file, IAssembly assembly) {
@@ -132,7 +136,7 @@ public class CLIComponent implements IComponent {
         final int typesCount = _cliFile.getTablesHeader().getRowCount(CLITableConstants.CLI_TABLE_TYPE_DEF);
         typeCache = new IType[typesCount];
         for (int i = 0; i < typesCount; i++) {
-            typeCache[i] = TypeFactory.create(_definingAssembly.getAppDomain().getContext(), _cliFile.getTableHeads().getTypeDefTableHead().skip(i), this);
+            typeCache[i] = TypeFactory.create(_cliFile.getTableHeads().getTypeDefTableHead().skip(i), this);
         }
     }
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/component/IComponent.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/component/IComponent.java
@@ -3,19 +3,19 @@ package com.vztekoverflow.cilostazol.runtime.typesystem.component;
 import com.vztekoverflow.cil.parser.cli.CLIFile;
 import com.vztekoverflow.cil.parser.cli.table.CLITablePtr;
 import com.vztekoverflow.cil.parser.cli.table.generated.CLITableHeads;
-import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
+import com.vztekoverflow.cilostazol.context.ContextAccess;
 import com.vztekoverflow.cilostazol.runtime.typesystem.assembly.IAssembly;
 import com.vztekoverflow.cilostazol.runtime.typesystem.type.IType;
 
-public interface IComponent {
+public interface IComponent extends ContextAccess {
     //TODO: CLIFile in IComponent ... get rid of it, or abandon IComponent completely?
     CLIFile getDefiningFile();
 
     IAssembly getDefiningAssembly();
 
-    IType getLocalType(CILOSTAZOLContext context, String namespace, String name);
+    IType getLocalType(String namespace, String name);
 
-    IType getLocalType(CILOSTAZOLContext context, CLITablePtr typeIndex);
+    IType getLocalType(CLITablePtr typeIndex);
 
     //TODO: CLITableHeads in IComponent ... get rid of it, or abandon IComponent completely?
     CLITableHeads getTableHeads();

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/field/factory/FieldFactory.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/field/factory/FieldFactory.java
@@ -16,7 +16,7 @@ public final class FieldFactory {
         final var signature = fieldRow.getSignatureHeapPtr().read(component.getDefiningFile().getBlobHeap());
 
         final FieldSig fieldSig = FieldSig.parse(new SignatureReader(signature));
-        final IType type = TypeFactory.create(context, fieldSig.getType(), mvars, vars, component);
+        final IType type = TypeFactory.create(fieldSig.getType(), mvars, vars, component);
         boolean isStatic = (fieldRow.getFlags() & 0x0010) != 0;
         boolean isInitOnly = (fieldRow.getFlags() & 0x0010) != 0;
         boolean isLiteral = (fieldRow.getFlags() & 0x0040) != 0;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/factory/FactoryUtils.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/factory/FactoryUtils.java
@@ -15,7 +15,7 @@ public final class FactoryUtils {
         while (count-- > 0) {
             for (CLIGenericParamTableRow row : component.getDefiningFile().getTableHeads().getGenericParamTableHead()) {
                 if (ptr.getTableId() == row.getOwnerTablePtr().getTableId() && ptr.getRowNo() == row.getOwnerTablePtr().getRowNo()) {
-                    result[row.getNumber()] = TypeParameterFactory.create(context, row, result, vars, component, component.getDefiningFile());
+                    result[row.getNumber()] = TypeParameterFactory.create(row, result, vars, component, component.getDefiningFile());
                 }
             }
         }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/factory/MethodFactory.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/method/factory/MethodFactory.java
@@ -11,7 +11,6 @@ import com.vztekoverflow.cilostazol.exceptions.NotImplementedException;
 import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.typesystem.TypeSystemException;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.CLIComponent;
-import com.vztekoverflow.cilostazol.runtime.typesystem.component.IComponent;
 import com.vztekoverflow.cilostazol.runtime.typesystem.generic.ITypeParameter;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.IMethod;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.NonGenericMethod;
@@ -36,13 +35,13 @@ import com.vztekoverflow.cilostazol.runtime.typesystem.type.NonGenericType;
 import com.vztekoverflow.cilostazol.runtime.typesystem.type.factory.TypeFactory;
 
 public final class MethodFactory {
-    public static IMethod create(CILOSTAZOLContext context, CLIMethodDefTableRow mDef, CLIType definingType) {
+    public static IMethod create(CLIMethodDefTableRow mDef, CLIType definingType) {
         final IType[] definingTypeParameters = (definingType instanceof NonGenericType) ? new IType[0] : definingType.getTypeParameters();
         final CLIFile file = definingType.getDefiningFile();
         final MethodDefSig mSignature = MethodDefSig.parse(new SignatureReader(mDef.getSignatureHeapPtr().read(file.getBlobHeap())), file);
         final String name = mDef.getNameHeapPtr().read(file.getStringHeap());
         final MethodFlags flags = new MethodFlags(mDef.getFlags());
-
+        final CILOSTAZOLContext context = definingType.getContext();
 
         // Type parameters parsing
         final ITypeParameter[] typeParameters = FactoryUtils.getTypeParameters(context, mSignature.getGenParamCount(), mDef.getPtr(), definingTypeParameters, definingType.getCLIComponent());
@@ -83,7 +82,6 @@ public final class MethodFactory {
                 else
                 {
                     locals = createLocals(
-                            context,
                             LocalVarsSig.read(new SignatureReader(file.getTableHeads().getStandAloneSigTableHead().skip(CLITablePtr.fromToken(localTok)).getSignatureHeapPtr().read(file.getBlobHeap())), file),
                             typeParameters,
                             definingTypeParameters,
@@ -103,7 +101,7 @@ public final class MethodFactory {
                 buf.setPosition(buf.getPosition() + codeSize);
                 buf.align(4);
 
-                handlers = createHandlers(context, buf, typeParameters, definingTypeParameters, definingType.getCLIComponent());
+                handlers = createHandlers(buf, typeParameters, definingTypeParameters, definingType.getCLIComponent());
             } else {
                 handlers = new IExceptionHandler[0];
             }
@@ -129,10 +127,10 @@ public final class MethodFactory {
         }
 
         //Return type parsing
-        IReturnType retType = new ReturnType(mSignature.getRetType().isByRef(), TypeFactory.create(context, mSignature.getRetType().getTypeSig(), typeParameters, definingTypeParameters, definingType.getCLIComponent()));
+        IReturnType retType = new ReturnType(mSignature.getRetType().isByRef(), TypeFactory.create(mSignature.getRetType().getTypeSig(), typeParameters, definingTypeParameters, definingType.getCLIComponent()));
 
         //Parameters parsing
-        final IParameter[] parameters = createParameters(context, mSignature.getParams(), params, typeParameters, definingTypeParameters, definingType.getCLIComponent());
+        final IParameter[] parameters = createParameters(mSignature.getParams(), params, typeParameters, definingTypeParameters, definingType.getCLIComponent());
 
         if (mSignature.getMethodDefFlags().hasFlag(MethodDefFlags.Flag.GENERIC))
             return new OpenGenericMethod(
@@ -184,20 +182,20 @@ public final class MethodFactory {
     }
 
     //region Helpers
-    private static ILocal[] createLocals(CILOSTAZOLContext context, LocalVarsSig signatures, IType[] mvars, IType[] vars, CLIComponent component)
+    private static ILocal[] createLocals(LocalVarsSig signatures, IType[] mvars, IType[] vars, CLIComponent component)
     {
         ILocal[] locals = new ILocal[signatures.getVarsCount()];
         for (int i = 0; i < locals.length; i++) {
             locals[i] = new Local(
                     signatures.getVars()[i].isByRef(),
                     signatures.getVars()[i].isPinned(),
-                    TypeFactory.create(context, signatures.getVars()[i].getTypeSig(), mvars, vars, component)
+                    TypeFactory.create(signatures.getVars()[i].getTypeSig(), mvars, vars, component)
             );
         }
         return locals;
     }
 
-    private static IExceptionHandler[] createHandlers(CILOSTAZOLContext context, ByteSequenceBuffer buf, IType[] mvars, IType[] vars, CLIComponent component)
+    private static IExceptionHandler[] createHandlers(ByteSequenceBuffer buf, IType[] mvars, IType[] vars, CLIComponent component)
     {
         final IExceptionHandler[] handlers;
         final byte kind = buf.getByte();
@@ -246,18 +244,18 @@ public final class MethodFactory {
                 classTokenOrFilterOffset = buf.getInt();
             }
             final IType klass = (flags.hasFlag(ExceptionClauseFlags.Flag.COR_ILEXCEPTION_CLAUSE_EXCEPTION))
-                    ? TypeFactory.create(context, CLITablePtr.fromToken(classTokenOrFilterOffset), mvars, vars, component)
+                    ? TypeFactory.create(CLITablePtr.fromToken(classTokenOrFilterOffset), mvars, vars, component)
                     : null;
             handlers[i] = new ExceptionHandler(tryoffset, trylength, handleroffset, handlerlength, klass, flags);
         }
         return  handlers;
     }
 
-    private static IParameter[] createParameters(CILOSTAZOLContext context, ParamSig[] params, CLIParamTableRow[] rows, IType[] mvars, IType[] vars, CLIComponent component)
+    private static IParameter[] createParameters(ParamSig[] params, CLIParamTableRow[] rows, IType[] mvars, IType[] vars, CLIComponent component)
     {
         final IParameter[] parameters = new IParameter[params.length];
         for (int i = 0; i < params.length; i++) {
-            parameters[i] = new Parameter(params[i].isByRef(), TypeFactory.create(context, params[i].getTypeSig(), mvars, vars, component), rows[i].getNameHeapPtr().read(component.getDefiningFile().getStringHeap()), rows[i].getSequence(), new ParamFlags(rows[i].getFlags()));
+            parameters[i] = new Parameter(params[i].isByRef(), TypeFactory.create(params[i].getTypeSig(), mvars, vars, component), rows[i].getNameHeapPtr().read(component.getDefiningFile().getStringHeap()), rows[i].getSequence(), new ParamFlags(rows[i].getFlags()));
         }
 
         return parameters;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/TypeBase.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/TypeBase.java
@@ -281,7 +281,7 @@ public abstract class TypeBase<T extends CLITableRow<T>> extends CLIType impleme
 
         var methods = new ArrayList<IMethod>();
         while (methodRow.getRowNo() < lastIdx) {
-            var method = MethodFactory.create(getContext(), methodRow, this);
+            var method = MethodFactory.create(methodRow, this);
             methods.add(method);
             methodRow = methodRow.next();
         }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/factory/FactoryUtils.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/factory/FactoryUtils.java
@@ -9,7 +9,6 @@ import com.vztekoverflow.cil.parser.cli.table.generated.CLITypeDefTableRow;
 import com.vztekoverflow.cilostazol.CILOSTAZOLBundle;
 import com.vztekoverflow.cilostazol.exceptions.NotImplementedException;
 import com.vztekoverflow.cilostazol.runtime.typesystem.TypeSystemException;
-import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.CLIComponent;
 import com.vztekoverflow.cilostazol.runtime.typesystem.generic.ITypeParameter;
 import com.vztekoverflow.cilostazol.runtime.typesystem.generic.TypeParameter;
@@ -22,7 +21,7 @@ import java.util.List;
 import java.util.Objects;
 
 public final class FactoryUtils {
-    static ITypeParameter[] getTypeParameters(CILOSTAZOLContext context, CLITypeDefTableRow ptr, CLIComponent component) {
+    static ITypeParameter[] getTypeParameters(CLITypeDefTableRow ptr, CLIComponent component) {
         var typeParameters = new ArrayList<CLIGenericParamTableRow>();
         for (CLIGenericParamTableRow row : component.getTableHeads().getGenericParamTableHead()) {
             final var genParamOwner = row.getOwnerTablePtr();
@@ -33,18 +32,18 @@ public final class FactoryUtils {
 
         ITypeParameter[] result = new TypeParameter[typeParameters.size()];
         for (CLIGenericParamTableRow row : typeParameters) {
-            result[row.getNumber()] = TypeParameterFactory.create(context, row, null, result, component, component.getDefiningFile());
+            result[row.getNumber()] = TypeParameterFactory.create(row, null, result, component, component.getDefiningFile());
         }
 
         return result;
     }
 
-    static IType[] getInterfaces(CILOSTAZOLContext context, String className, String classNamespace, CLIComponent component) {
+    static IType[] getInterfaces(String className, String classNamespace, CLIComponent component) {
         List<IType> interfaces = new ArrayList<>();
         //TODO: implement case for ref and spec table
         for (var interfaceRow : component.getTableHeads().getInterfaceImplTableHead()) {
             if (interfaceExtendsClass(interfaceRow, className, classNamespace, component)) {
-                interfaces.add(getInterface(context, interfaceRow, component));
+                interfaces.add(getInterface(interfaceRow, component));
             }
         }
 
@@ -61,31 +60,31 @@ public final class FactoryUtils {
         return extendingClassName.equals(potentialClassName) && extendingClassNamespace.equals(potentialClassNamespace);
     }
 
-    static IType getInterface(CILOSTAZOLContext context, CLIInterfaceImplTableRow row, CLIComponent component) {
+    static IType getInterface(CLIInterfaceImplTableRow row, CLIComponent component) {
         CLITablePtr tablePtr = row.getInterfaceTablePtr();
         return switch (tablePtr.getTableId()) {
-            case CLITableConstants.CLI_TABLE_TYPE_DEF -> component.getLocalType(context, tablePtr);
+            case CLITableConstants.CLI_TABLE_TYPE_DEF -> component.getLocalType(tablePtr);
             case CLITableConstants.CLI_TABLE_TYPE_REF -> null; //TODO: implement case for ref table
             case CLITableConstants.CLI_TABLE_TYPE_SPEC -> null; //TODO: implement case for spec table
             default -> throw new NotImplementedException();
         };
     }
 
-    static IType getDirectBaseClass(CILOSTAZOLContext context, CLITypeDefTableRow typeDefRow, IType[] mvars, IType[] vars,CLIComponent component) {
+    static IType getDirectBaseClass(CLITypeDefTableRow typeDefRow, IType[] mvars, IType[] vars, CLIComponent component) {
         CLITablePtr tablePtr = typeDefRow.getExtendsTablePtr();
         if (tablePtr.isEmpty()) return null;
 
         IType baseClass;
         switch (tablePtr.getTableId()) {
-            case CLITableConstants.CLI_TABLE_TYPE_DEF -> baseClass = component.getLocalType(context, tablePtr);
-            case CLITableConstants.CLI_TABLE_TYPE_REF -> baseClass = TypeFactory.create(context, component.getDefiningFile().getTableHeads().getTypeRefTableHead().skip(tablePtr), component);
-            case CLITableConstants.CLI_TABLE_TYPE_SPEC -> baseClass = TypeFactory.create(context, component.getDefiningFile().getTableHeads().getTypeSpecTableHead().skip(tablePtr), mvars, vars, component);
+            case CLITableConstants.CLI_TABLE_TYPE_DEF -> baseClass = component.getLocalType(tablePtr);
+            case CLITableConstants.CLI_TABLE_TYPE_REF -> baseClass = TypeFactory.create(component.getDefiningFile().getTableHeads().getTypeRefTableHead().skip(tablePtr), component);
+            case CLITableConstants.CLI_TABLE_TYPE_SPEC -> baseClass = TypeFactory.create(component.getDefiningFile().getTableHeads().getTypeSpecTableHead().skip(tablePtr), mvars, vars, component);
             default -> throw new NotImplementedException();
         }
         return baseClass;
     }
 
-    static IType getTypeFromDifferentModule(CILOSTAZOLContext context, CLIComponent component, String name, String namespace, CLITablePtr resolutionScopeTablePtr) {
+    static IType getTypeFromDifferentModule(CLIComponent component, String name, String namespace, CLITablePtr resolutionScopeTablePtr) {
         //TODO: I feel like getting tables should be done via something else that component -> some assembly appDomain/Assembly singleton maybe?
         var moduleRefName = component.getNameFrom(component.getTableHeads().getModuleRefTableHead().skip(resolutionScopeTablePtr));
 
@@ -94,7 +93,7 @@ public final class FactoryUtils {
                 .filter(c -> c.getDefiningFile().getName().equals(moduleRefName))
                 .findFirst()
                 .orElseThrow(() -> new TypeSystemException(CILOSTAZOLBundle.message("cilostazol.exception.moduleRefNotFound", moduleRefName)));
-        return definingComponent.getLocalType(context, name, namespace);
+        return definingComponent.getLocalType(name, namespace);
     }
 
     static IType getTypeFromDifferentAssembly(CLIComponent component, String name, String namespace, CLITablePtr resolutionScopeTablePtr) {

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/factory/TypeFactory.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/type/factory/TypeFactory.java
@@ -10,11 +10,9 @@ import com.vztekoverflow.cil.parser.cli.table.generated.CLITypeDefTableRow;
 import com.vztekoverflow.cil.parser.cli.table.generated.CLITypeRefTableRow;
 import com.vztekoverflow.cil.parser.cli.table.generated.CLITypeSpecTableRow;
 import com.vztekoverflow.cilostazol.CILOSTAZOLBundle;
-import com.vztekoverflow.cilostazol.CILOSTAZOLLanguage;
-import com.vztekoverflow.cilostazol.context.ContextAccess;
-import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.exceptions.InvalidCLIException;
 import com.vztekoverflow.cilostazol.exceptions.NotImplementedException;
+import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.typesystem.TypeSystemException;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.CLIComponent;
 import com.vztekoverflow.cilostazol.runtime.typesystem.generic.Substitution;
@@ -23,25 +21,26 @@ import com.vztekoverflow.cilostazol.runtime.typesystem.type.NonGenericType;
 import com.vztekoverflow.cilostazol.runtime.typesystem.type.OpenGenericType;
 
 public final class TypeFactory {
-    public static IType create(CILOSTAZOLContext context, CLITablePtr ptr, IType[] mvars, IType[] vars, CLIComponent component) {
+    public static IType create(CLITablePtr ptr, IType[] mvars, IType[] vars, CLIComponent component) {
         return switch (ptr.getTableId()) {
             case CLITableConstants.CLI_TABLE_TYPE_DEF ->
-                    component.getLocalType(context, ptr);
+                    component.getLocalType(ptr);
             case CLITableConstants.CLI_TABLE_TYPE_REF ->
-                    TypeFactory.create(context, component.getDefiningFile().getTableHeads().getTypeRefTableHead().skip(ptr), component);
+                    TypeFactory.create(component.getDefiningFile().getTableHeads().getTypeRefTableHead().skip(ptr), component);
             case CLITableConstants.CLI_TABLE_TYPE_SPEC ->
-                    TypeFactory.create(context, component.getDefiningFile().getTableHeads().getTypeSpecTableHead().skip(ptr), mvars, vars, component);
+                    TypeFactory.create(component.getDefiningFile().getTableHeads().getTypeSpecTableHead().skip(ptr), mvars, vars, component);
             default ->
                     throw new TypeSystemException(CILOSTAZOLBundle.message("cilostazol.exception.constructor.withoutDefType"));
         };
     }
 
-    public static IType create(CILOSTAZOLContext context, CLITypeDefTableRow typeDefRow, CLIComponent component) {
+    public static IType create(CLITypeDefTableRow typeDefRow, CLIComponent component) {
+        CILOSTAZOLContext context = component.getContext();
         String name = component.getNameFrom(typeDefRow);
         String namespace = component.getNamespaceFrom(typeDefRow);
-        IType[] interfaces = FactoryUtils.getInterfaces(context, name, namespace, component);
-        IType[] genericParameters = FactoryUtils.getTypeParameters(context, typeDefRow, component);
-        IType directBaseClass = FactoryUtils.getDirectBaseClass(context, typeDefRow, new IType[0], genericParameters,component);
+        IType[] interfaces = FactoryUtils.getInterfaces(name, namespace, component);
+        IType[] genericParameters = FactoryUtils.getTypeParameters(typeDefRow, component);
+        IType directBaseClass = FactoryUtils.getDirectBaseClass(typeDefRow, new IType[0], genericParameters,component);
         int flags = typeDefRow.getFlags();
         if (genericParameters.length == 0) {
             return new NonGenericType<>(context,
@@ -67,12 +66,12 @@ public final class TypeFactory {
         }
     }
 
-    public static IType create(CILOSTAZOLContext context, CLITypeSpecTableRow type, IType[] methodTypeParameters, IType[] classTypeParameters, CLIComponent component) {
+    public static IType create(CLITypeSpecTableRow type, IType[] methodTypeParameters, IType[] classTypeParameters, CLIComponent component) {
         TypeSig signature = TypeSig.read(new SignatureReader(type.getSignatureHeapPtr().read(component.getDefiningFile().getBlobHeap())), component.getDefiningFile());
-        return create(context, signature, methodTypeParameters, classTypeParameters, component);
+        return create(signature, methodTypeParameters, classTypeParameters, component);
     }
 
-    public static IType create(CILOSTAZOLContext context,CLITypeRefTableRow type, CLIComponent component) {
+    public static IType create(CLITypeRefTableRow type, CLIComponent component) {
         var name = component.getNameFrom(type);
         var namespace = component.getNamespaceFrom(type);
 
@@ -86,7 +85,7 @@ public final class TypeFactory {
             case CLITableConstants.CLI_TABLE_TYPE_REF ->
                     throw new UnsupportedOperationException(CILOSTAZOLBundle.message("cilostazol.exception.typeRefResolutionScope"));
             case CLITableConstants.CLI_TABLE_MODULE_REF ->
-                    FactoryUtils.getTypeFromDifferentModule(context, component, name, namespace, resolutionScopeTablePtr);
+                    FactoryUtils.getTypeFromDifferentModule(component, name, namespace, resolutionScopeTablePtr);
             case CLITableConstants.CLI_TABLE_MODULE -> throw new InvalidCLIException();
             case CLITableConstants.CLI_TABLE_ASSEMBLY_REF ->
                     FactoryUtils.getTypeFromDifferentAssembly(component, name, namespace, resolutionScopeTablePtr);
@@ -95,15 +94,15 @@ public final class TypeFactory {
         };
     }
 
-    public static IType create(CILOSTAZOLContext context, TypeSpecSig typeSig, IType[] mvars, IType[] vars, CLIComponent definingComponent) {
+    public static IType create(TypeSpecSig typeSig, IType[] mvars, IType[] vars, CLIComponent definingComponent) {
         //TODO: null reference exception might have occured here if TypeSig is not created from CLASS
         //TODO: resolve for other types (SZARRAY, GENERICINST, ...)
         if (typeSig.getFlag().getFlag() == ElementTypeFlag.Flag.ELEMENT_TYPE_GENERICINST)
         {
-            IType genType = TypeFactory.create(context, typeSig.getGenType(), mvars, vars, definingComponent);
+            IType genType = TypeFactory.create(typeSig.getGenType(), mvars, vars, definingComponent);
             IType[] typeArgs = new IType[typeSig.getTypeArgs().length];
             for (int i = 0; i < typeArgs.length; i++) {
-                typeArgs[i] = TypeFactory.create(context, typeSig.getTypeArgs()[i], mvars, vars, definingComponent);
+                typeArgs[i] = TypeFactory.create(typeSig.getTypeArgs()[i], mvars, vars, definingComponent);
             }
             return genType.substitute(new Substitution<>(genType.getTypeParameters(), typeArgs));
         }
@@ -121,12 +120,12 @@ public final class TypeFactory {
         }
     }
 
-    public static IType create(CILOSTAZOLContext context, TypeSig typeSig, IType[] mvars, IType[] vars, CLIComponent definingComponent) {
+    public static IType create(TypeSig typeSig, IType[] mvars, IType[] vars, CLIComponent definingComponent) {
         //TODO: null reference exception might have occured here if TypeSig is not created from CLASS
         //TODO: resolve for other types (SZARRAY, GENERICINST, ...)
         if (typeSig.getElementType() == TypeSig.ELEMENT_TYPE_VALUETYPE
             || typeSig.getElementType() == TypeSig.ELEMENT_TYPE_CLASS)
-            return create(context, typeSig.getCliTablePtr(), mvars, vars, definingComponent);
+            return create(typeSig.getCliTablePtr(), mvars, vars, definingComponent);
         else if (typeSig.getElementType() == TypeSig.ELEMENT_TYPE_VAR)
         {
             return vars[typeSig.getIndex()];
@@ -137,10 +136,10 @@ public final class TypeFactory {
         }
         else if (typeSig.getElementType() == TypeSig.ELEMENT_TYPE_GENERICINST)
         {
-            IType genType = TypeFactory.create(context, typeSig.getCliTablePtr(), mvars, vars, definingComponent);
+            IType genType = TypeFactory.create(typeSig.getCliTablePtr(), mvars, vars, definingComponent);
             IType[] typeArgs = new IType[typeSig.getTypeArgs().length];
             for (int i = 0; i < typeArgs.length; i++) {
-                typeArgs[i] = TypeFactory.create(context, typeSig.getTypeArgs()[i], mvars, vars, definingComponent);
+                typeArgs[i] = TypeFactory.create(typeSig.getTypeArgs()[i], mvars, vars, definingComponent);
             }
             return genType.substitute(new Substitution<>(genType.getTypeParameters(), typeArgs));
         }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/typeparameters/factory/TypeParameterFactory.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/typesystem/typeparameters/factory/TypeParameterFactory.java
@@ -3,7 +3,6 @@ package com.vztekoverflow.cilostazol.runtime.typesystem.typeparameters.factory;
 import com.vztekoverflow.cil.parser.cli.CLIFile;
 import com.vztekoverflow.cil.parser.cli.table.generated.CLIGenericParamConstraintTableRow;
 import com.vztekoverflow.cil.parser.cli.table.generated.CLIGenericParamTableRow;
-import com.vztekoverflow.cilostazol.runtime.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.CLIComponent;
 import com.vztekoverflow.cilostazol.runtime.typesystem.generic.GenericParameterFlags;
 import com.vztekoverflow.cilostazol.runtime.typesystem.generic.TypeParameter;
@@ -14,20 +13,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class TypeParameterFactory {
-    public static TypeParameter create(CILOSTAZOLContext context, CLIGenericParamTableRow row, IType[] mvars, IType[] vars, CLIComponent definingComponent, CLIFile file) {
+    public static TypeParameter create(CLIGenericParamTableRow row, IType[] mvars, IType[] vars, CLIComponent definingComponent, CLIFile file) {
         final short flags = row.getFlags();
         return new TypeParameter(
-                getConstrains(context, row, mvars, vars, definingComponent),
+                getConstrains(row, mvars, vars, definingComponent),
                 new GenericParameterFlags(flags),
                 row.getNumber(),
                 row.getNameHeapPtr().read(file.getStringHeap()));
     }
 
-    private static IType[] getConstrains(CILOSTAZOLContext context, CLIGenericParamTableRow row, IType[] mvars, IType[] vars, CLIComponent component) {
+    private static IType[] getConstrains(CLIGenericParamTableRow row, IType[] mvars, IType[] vars, CLIComponent component) {
         List<IType> constrains = new ArrayList<>();
         for (CLIGenericParamConstraintTableRow r : component.getDefiningFile().getTableHeads().getGenericParamConstraintTableHead()) {
             if (row.getTableId() == r.getOwnerTablePtr().getTableId() && row.getRowNo() == r.getOwnerTablePtr().getRowNo()) {
-                constrains.add(TypeFactory.create(context, r.getConstraintTablePtr(), mvars, vars, component));
+                constrains.add(TypeFactory.create(r.getConstraintTablePtr(), mvars, vars, component));
             }
         }
 

--- a/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/MethodParsingTests.java
+++ b/language/src/test/java/com/vztekoverflow/cilostazol/runtime/typesystem/MethodParsingTests.java
@@ -9,7 +9,6 @@ import com.vztekoverflow.cilostazol.runtime.typesystem.appdomain.IAppDomain;
 import com.vztekoverflow.cilostazol.runtime.typesystem.assembly.Assembly;
 import com.vztekoverflow.cilostazol.runtime.typesystem.assembly.IAssembly;
 import com.vztekoverflow.cilostazol.runtime.typesystem.component.CLIComponent;
-import com.vztekoverflow.cilostazol.runtime.typesystem.component.IComponent;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.IMethod;
 import com.vztekoverflow.cilostazol.runtime.typesystem.method.factory.MethodFactory;
 import com.vztekoverflow.cilostazol.runtime.typesystem.type.CLIType;
@@ -35,11 +34,11 @@ public class MethodParsingTests extends TestBase {
 
         final CLIComponent component = (CLIComponent) assembly.getComponents()[0];
         //Classes
-        final CLIType classA = (CLIType)component.getLocalType(ctx, "MethodParsingGeneral", "A");
+        final CLIType classA = (CLIType)component.getLocalType("MethodParsingGeneral", "A");
         //final IType interfaceAI= component.getLocalType("MethodParsingGeneral","AI");
-        final CLIType classG_T = (CLIType)component.getLocalType(ctx, "MethodParsingGeneral", "G`1");
-        final CLIType classBar1 = (CLIType)component.getLocalType(ctx, "MethodParsingGeneral", "Bar1");
-        final CLIType classBar2 = (CLIType)component.getLocalType(ctx,"MethodParsingGeneral", "Bar2`1");
+        final CLIType classG_T = (CLIType)component.getLocalType("MethodParsingGeneral", "G`1");
+        final CLIType classBar1 = (CLIType)component.getLocalType("MethodParsingGeneral", "Bar1");
+        final CLIType classBar2 = (CLIType)component.getLocalType("MethodParsingGeneral", "Bar2`1");
 
         final CLIMethodDefTableRow method_def_Bar1_Foo1 = CLIFileUtils.getMethodByName("Bar1_Foo1", component.getDefiningFile())[0];
         final CLIMethodDefTableRow method_def_Bar1_Foo2 = CLIFileUtils.getMethodByName("Bar1_Foo2", component.getDefiningFile())[0];
@@ -53,18 +52,18 @@ public class MethodParsingTests extends TestBase {
         final CLIMethodDefTableRow method_def_Bar1_Foo10 = CLIFileUtils.getMethodByName("Bar1_Foo10", component.getDefiningFile())[0];
         final CLIMethodDefTableRow method_def_Bar2_Foo1 = CLIFileUtils.getMethodByName("Bar2_Foo1", component.getDefiningFile())[0];
 
-        final IMethod method_Bar1_Foo1 = MethodFactory.create(ctx, method_def_Bar1_Foo1, classBar1);
+        final IMethod method_Bar1_Foo1 = MethodFactory.create(method_def_Bar1_Foo1, classBar1);
         Assert.assertEquals(method_Bar1_Foo1.getName(), "Bar1_Foo1");
-        final IMethod method_Bar1_Foo2 = MethodFactory.create(ctx, method_def_Bar1_Foo2, classBar1);
-        final IMethod method_Bar1_Foo3 = MethodFactory.create(ctx, method_def_Bar1_Foo3, classBar1);
-        final IMethod method_Bar1_Foo4 = MethodFactory.create(ctx, method_def_Bar1_Foo4, classBar1);
-        final IMethod method_Bar1_Foo5 = MethodFactory.create(ctx, method_def_Bar1_Foo5, classBar1);
-        final IMethod method_Bar1_Foo6 = MethodFactory.create(ctx, method_def_Bar1_Foo6, classBar1);
-        final IMethod method_Bar1_Foo7 = MethodFactory.create(ctx, method_def_Bar1_Foo7, classBar1);
-        final IMethod method_Bar1_Foo8 = MethodFactory.create(ctx, method_def_Bar1_Foo8, classBar1);
-        final IMethod method_Bar1_Foo9 = MethodFactory.create(ctx, method_def_Bar1_Foo9, classBar1);
-        final IMethod method_Bar1_Foo10 = MethodFactory.create(ctx, method_def_Bar1_Foo10, classBar1);
-        final IMethod method_Bar2_Foo1 = MethodFactory.create(ctx, method_def_Bar2_Foo1, classBar2);
+        final IMethod method_Bar1_Foo2 = MethodFactory.create(method_def_Bar1_Foo2, classBar1);
+        final IMethod method_Bar1_Foo3 = MethodFactory.create(method_def_Bar1_Foo3, classBar1);
+        final IMethod method_Bar1_Foo4 = MethodFactory.create(method_def_Bar1_Foo4, classBar1);
+        final IMethod method_Bar1_Foo5 = MethodFactory.create(method_def_Bar1_Foo5, classBar1);
+        final IMethod method_Bar1_Foo6 = MethodFactory.create(method_def_Bar1_Foo6, classBar1);
+        final IMethod method_Bar1_Foo7 = MethodFactory.create(method_def_Bar1_Foo7, classBar1);
+        final IMethod method_Bar1_Foo8 = MethodFactory.create(method_def_Bar1_Foo8, classBar1);
+        final IMethod method_Bar1_Foo9 = MethodFactory.create(method_def_Bar1_Foo9, classBar1);
+        final IMethod method_Bar1_Foo10 = MethodFactory.create(method_def_Bar1_Foo10, classBar1);
+        final IMethod method_Bar2_Foo1 = MethodFactory.create(method_def_Bar2_Foo1, classBar2);
     }
 
     public void testMethodParsing_MethodExistence() throws IOException {


### PR DESCRIPTION
Expose CILOSTAZOLContext using interfaces

Use ContextAccess and ContextAccessImpl to allow arbitrary types 
to expose CILOSTAZOLContext and CILOSTAZOLLanguage.

Simplify usages of context and language getters caused by #8 