### PR TITLE
Parsing: Fix RVA for System.Object

### DIFF
--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
@@ -36,14 +36,13 @@ public class MethodSymbol extends Symbol {
   protected final ExceptionHandlerSymbol[] exceptionHandlers;
   protected final byte[] cil;
   protected final byte[] originalCil;
-
-  @CompilerDirectives.CompilationFinal(dimensions = 1)
-  private StaticOpCodeAnalyser.OpCodeType[] opCodeTypes = null;
   // body
   protected final int maxStack;
   protected final MethodHeaderFlags methodHeaderFlags;
-
   @CompilerDirectives.CompilationFinal protected RootNode node;
+
+  @CompilerDirectives.CompilationFinal(dimensions = 1)
+  private StaticOpCodeAnalyser.OpCodeType[] opCodeTypes = null;
 
   protected MethodSymbol(
       String name,
@@ -251,15 +250,14 @@ public class MethodSymbol extends Symbol {
       final byte[] cil;
       final ExceptionHandlerSymbol[] handlers;
 
-      // Method header parsing
-      if (!flags.hasFlag(MethodFlags.Flag.ABSTRACT)) {
-        int rva = mDef.getRVA();
-        if (rva == 0) {
-          // TODO: Remove this workaround, see if this only happens with System.Object::GetType
-          rva = mDef.getRVA(8);
-        }
-        final ByteSequenceBuffer buf = file.getBuffer(rva);
+      int rva = mDef.getRVA();
+      if (rva == 0)
+        System.err.println(
+            "Warning: Method " + name + " has no RVA (likely tagged as extern), skipping.");
 
+      // Method header parsing
+      if (rva != 0 && !flags.hasFlag(MethodFlags.Flag.ABSTRACT)) {
+        final ByteSequenceBuffer buf = file.getBuffer(rva);
         final byte firstByte = buf.getByte();
         final MethodHeaderFlags pom = new MethodHeaderFlags(firstByte);
         if (pom.hasFlag(MethodHeaderFlags.Flag.CORILMETHOD_TINYFORMAT)) {

--- a/tests/src/test/java/com/vztekoverflow/cilostazol/tests/ObjectModelTests.java
+++ b/tests/src/test/java/com/vztekoverflow/cilostazol/tests/ObjectModelTests.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class ObjectManipulationTests extends TestBase {
+public class ObjectModelTests extends TestBase {
   @Test
   public void createObject() {
     var result =


### PR DESCRIPTION
Ignore the MethodDef and print a warning for methods that are extern.