### PR TITLE
SOM: Call .cctor when appropriate

### DIFF
--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILOSTAZOLFrame.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILOSTAZOLFrame.java
@@ -330,7 +330,6 @@ public final class CILOSTAZOLFrame {
     assert sourceSlot >= 0 && destSlot >= 0;
     frame.copyStatic(sourceSlot, destSlot);
   }
-  // endregion
 
   // region stack types
   public enum StackType {
@@ -341,4 +340,5 @@ public final class CILOSTAZOLFrame {
     NativeInt,
     ManagedPointer,
   }
+  // endregion
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CallEntryPointCallTarget.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CallEntryPointCallTarget.java
@@ -32,7 +32,6 @@ public final class CallEntryPointCallTarget implements CallTarget {
     int i = 0;
     for (var appArg : ctx.getEnv().getApplicationArguments()) {
       var javaArr = ctx.getArrayProperty().getObject(arg);
-      // TODO: Bootstrap no frame
       Array.set(javaArr, i, ctx.getAllocator().createString(appArg, null, 0));
       i++;
     }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CallEntryPointCallTarget.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CallEntryPointCallTarget.java
@@ -32,7 +32,8 @@ public final class CallEntryPointCallTarget implements CallTarget {
     int i = 0;
     for (var appArg : ctx.getEnv().getApplicationArguments()) {
       var javaArr = ctx.getArrayProperty().getObject(arg);
-      Array.set(javaArr, i, ctx.getAllocator().createString(appArg));
+      // TODO: Bootstrap no frame
+      Array.set(javaArr, i, ctx.getAllocator().createString(appArg, null, 0));
       i++;
     }
   }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/nodeized/NEWOBJNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/nodeized/NEWOBJNode.java
@@ -34,7 +34,8 @@ public class NEWOBJNode extends NodeizedNodeBase {
     Object[] args = getMethodArgsFromStack(frame);
 
     // Then, create the object as arg0
-    StaticObject object = CILOSTAZOLContext.get(this).getAllocator().createNew(type);
+    StaticObject object =
+        CILOSTAZOLContext.get(this).getAllocator().createNew(type, frame, topStack);
     args[0] = object;
 
     // Finally, call the constructor and push the result to the stack

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/nodeized/PRINTNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/nodeized/PRINTNode.java
@@ -45,11 +45,12 @@ public class PRINTNode extends NodeizedNodeBase {
   private StringBuilder getStringFromFrame(VirtualFrame frame) {
     var stringObject = CILOSTAZOLFrame.getLocalObject(frame, argumentTop);
     var namedTypeSymbol = (NamedTypeSymbol) stringObject.getTypeSymbol();
-    var length = namedTypeSymbol.getInstanceFields()[0].getInt(stringObject);
+    var length = namedTypeSymbol.getInstanceFields(frame, originalTop)[0].getInt(stringObject);
     var charArray =
         CILOSTAZOLContext.get(null)
             .getArrayProperty()
-            .getObject(namedTypeSymbol.getInstanceFields()[1].getObject(stringObject));
+            .getObject(
+                namedTypeSymbol.getInstanceFields(frame, originalTop)[1].getObject(stringObject));
 
     StringBuilder result = new StringBuilder();
     for (int i = 0; i < length; i++) {

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/objectmodel/LinkedFieldLayout.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/objectmodel/LinkedFieldLayout.java
@@ -1,6 +1,7 @@
 package com.vztekoverflow.cilostazol.runtime.objectmodel;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.staticobject.StaticShape;
 import com.vztekoverflow.cilostazol.runtime.context.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.symbols.FieldSymbol;
@@ -25,7 +26,9 @@ public final class LinkedFieldLayout {
       NamedTypeSymbol parserTypeSymbol,
       NamedTypeSymbol superClass,
       Map<FieldSymbol, Integer> instanceFieldMapping,
-      Map<FieldSymbol, Integer> staticFieldMapping) {
+      Map<FieldSymbol, Integer> staticFieldMapping,
+      VirtualFrame frame,
+      int topStack) {
     StaticShape.Builder instanceBuilder = StaticShape.newBuilder(description.getLanguage());
     StaticShape.Builder staticBuilder = StaticShape.newBuilder(description.getLanguage());
 
@@ -62,7 +65,7 @@ public final class LinkedFieldLayout {
       instanceShape =
           instanceBuilder.build(StaticObject.class, StaticObject.StaticObjectFactory.class);
     } else {
-      instanceShape = instanceBuilder.build(superClass.getShape(false));
+      instanceShape = instanceBuilder.build(superClass.getShape(frame, topStack, false));
     }
     staticShape = staticBuilder.build(StaticObject.class, StaticObject.StaticObjectFactory.class);
     fieldTableLength = nextInstanceFieldSlot;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/other/SymbolResolver.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/other/SymbolResolver.java
@@ -439,7 +439,6 @@ public final class SymbolResolver {
         MethodRefSig.parse(
             new SignatureReader(
                 row.getSignatureHeapPtr().read(module.getDefiningFile().getBlobHeap())));
-    var retType = resolveType(sig.getRetType().getTypeSig(), methodTypeArgs, typeTypeArgs, module);
     var paramTypes = new TypeSymbol[sig.getParams().length];
     for (int i = 0; i < paramTypes.length; i++) {
       paramTypes[i] =
@@ -453,7 +452,6 @@ public final class SymbolResolver {
             ? ((NamedTypeSymbol) type).getTypeArguments()
             : new TypeSymbol[0],
         paramTypes,
-        retType,
         sig.getGenParamCount());
   }
 
@@ -486,7 +484,6 @@ public final class SymbolResolver {
       String methodName,
       TypeSymbol[] typeArgs,
       TypeSymbol[] parameterTypes,
-      TypeSymbol returnType,
       int genParams) {
     // Note: CSharp prohibits overloading on return type, so we can ignore return type
     // TODO: resolving virtual methods

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
@@ -251,13 +251,14 @@ public class MethodSymbol extends Symbol {
       final ExceptionHandlerSymbol[] handlers;
 
       int rva = mDef.getRVA();
-      if (rva == 0)
+      if (rva == 0) {
         System.err.println(
             "Warning: Method "
                 + definingType.getName()
                 + "::"
                 + name
                 + " has no RVA (likely tagged as extern), skipping.");
+      }
 
       // Method header parsing
       if (rva != 0 && !flags.hasFlag(MethodFlags.Flag.ABSTRACT)) {

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
@@ -36,14 +36,13 @@ public class MethodSymbol extends Symbol {
   protected final ExceptionHandlerSymbol[] exceptionHandlers;
   protected final byte[] cil;
   protected final byte[] originalCil;
-
-  @CompilerDirectives.CompilationFinal(dimensions = 1)
-  private StaticOpCodeAnalyser.OpCodeType[] opCodeTypes = null;
   // body
   protected final int maxStack;
   protected final MethodHeaderFlags methodHeaderFlags;
-
   @CompilerDirectives.CompilationFinal protected RootNode node;
+
+  @CompilerDirectives.CompilationFinal(dimensions = 1)
+  private StaticOpCodeAnalyser.OpCodeType[] opCodeTypes = null;
 
   protected MethodSymbol(
       String name,
@@ -251,15 +250,18 @@ public class MethodSymbol extends Symbol {
       final byte[] cil;
       final ExceptionHandlerSymbol[] handlers;
 
-      // Method header parsing
-      if (!flags.hasFlag(MethodFlags.Flag.ABSTRACT)) {
-        int rva = mDef.getRVA();
-        if (rva == 0) {
-          // TODO: Remove this workaround, see if this only happens with System.Object::GetType
-          rva = mDef.getRVA(8);
-        }
-        final ByteSequenceBuffer buf = file.getBuffer(rva);
+      int rva = mDef.getRVA();
+      if (rva == 0)
+        System.err.println(
+            "Warning: Method "
+                + definingType.getName()
+                + "::"
+                + name
+                + " has no RVA (likely tagged as extern), skipping.");
 
+      // Method header parsing
+      if (rva != 0 && !flags.hasFlag(MethodFlags.Flag.ABSTRACT)) {
+        final ByteSequenceBuffer buf = file.getBuffer(rva);
         final byte firstByte = buf.getByte();
         final MethodHeaderFlags pom = new MethodHeaderFlags(firstByte);
         if (pom.hasFlag(MethodHeaderFlags.Flag.CORILMETHOD_TINYFORMAT)) {

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
@@ -334,7 +334,7 @@ public class MethodSymbol extends Symbol {
       CLIParamTableRow paramRow =
           file.getTableHeads().getParamTableHead().skip(mDef.getParamListTablePtr());
       for (int i = 0; i < params.length; i++) {
-        params[paramRow.getSequence() - 1] = paramRow;
+        params[i] = paramRow;
         paramRow = paramRow.next();
       }
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/NamedTypeSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/NamedTypeSymbol.java
@@ -382,11 +382,10 @@ public class NamedTypeSymbol extends TypeSymbol {
       return;
     }
 
-    for (MethodSymbol method : getMethods()) {
-      if (method.getName().equals(".cctor")) {
-        callStaticConstructor(frame, topStack, method);
-        break;
-      }
+    var classMember =
+        SymbolResolver.resolveMethod(this, ".cctor", new TypeSymbol[0], new TypeSymbol[0], 0);
+    if (classMember != null) {
+      callStaticConstructor(frame, topStack, classMember.member);
     }
   }
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/NamedTypeSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/NamedTypeSymbol.java
@@ -1,6 +1,8 @@
 package com.vztekoverflow.cilostazol.runtime.symbols;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.staticobject.StaticShape;
 import com.vztekoverflow.cil.parser.cli.AssemblyIdentity;
 import com.vztekoverflow.cil.parser.cli.CLIFileUtils;
@@ -13,6 +15,7 @@ import com.vztekoverflow.cilostazol.exceptions.InvalidCLIException;
 import com.vztekoverflow.cilostazol.exceptions.NotImplementedException;
 import com.vztekoverflow.cilostazol.exceptions.TypeSystemException;
 import com.vztekoverflow.cilostazol.nodes.CILOSTAZOLFrame;
+import com.vztekoverflow.cilostazol.nodes.nodeized.CALLNode;
 import com.vztekoverflow.cilostazol.runtime.context.CILOSTAZOLContext;
 import com.vztekoverflow.cilostazol.runtime.objectmodel.LinkedFieldLayout;
 import com.vztekoverflow.cilostazol.runtime.objectmodel.StaticField;
@@ -217,27 +220,28 @@ public class NamedTypeSymbol extends TypeSymbol {
     return lazyFields;
   }
 
-  public StaticField getAssignableInstanceField(FieldSymbol field) {
+  public StaticField getAssignableInstanceField(
+      FieldSymbol field, VirtualFrame frame, int topStack) {
     if (instanceShape == null) {
-      createShapes();
+      createShapes(frame, topStack);
     }
 
     assert !field.isStatic();
     return instanceFields[instanceFieldIndexMapping.get(field)];
   }
 
-  public StaticField getAssignableStaticField(FieldSymbol field) {
+  public StaticField getAssignableStaticField(FieldSymbol field, VirtualFrame frame, int topStack) {
     if (staticShape == null) {
-      createShapes();
+      createShapes(frame, topStack);
     }
 
     assert field.isStatic();
     return staticFields[staticFieldIndexMapping.get(field)];
   }
 
-  public StaticObject getStaticInstance() {
+  public StaticObject getStaticInstance(VirtualFrame frame, int topStack) {
     if (staticInstance == null) {
-      createShapes();
+      createShapes(frame, topStack);
     }
 
     return staticInstance;
@@ -327,31 +331,32 @@ public class NamedTypeSymbol extends TypeSymbol {
   // endregion
 
   // region SOM shapes
-  public StaticShape<StaticObject.StaticObjectFactory> getShape(boolean isStatic) {
+  public StaticShape<StaticObject.StaticObjectFactory> getShape(
+      VirtualFrame frame, int topStack, boolean isStatic) {
     if (isStatic && staticShape == null || !isStatic && instanceShape == null) {
-      createShapes();
+      createShapes(frame, topStack);
     }
 
     return isStatic ? staticShape : instanceShape;
   }
 
-  public StaticField[] getInstanceFields() {
+  public StaticField[] getInstanceFields(VirtualFrame frame, int topStack) {
     if (instanceShape == null) {
-      createShapes();
+      createShapes(frame, topStack);
     }
 
     return instanceFields;
   }
 
-  public StaticField[] getStaticFields() {
+  public StaticField[] getStaticFields(VirtualFrame frame, int topStack) {
     if (staticFields == null) {
-      createShapes();
+      createShapes(frame, topStack);
     }
 
     return staticFields;
   }
 
-  private void createShapes() {
+  private void createShapes(VirtualFrame frame, int topStack) {
     CompilerDirectives.transferToInterpreterAndInvalidate();
 
     LinkedFieldLayout layout =
@@ -360,16 +365,30 @@ public class NamedTypeSymbol extends TypeSymbol {
             this,
             getDirectBaseClass(),
             instanceFieldIndexMapping,
-            staticFieldIndexMapping);
+            staticFieldIndexMapping,
+            frame,
+            topStack);
     instanceShape = layout.instanceShape;
     staticShape = layout.staticShape;
     instanceFields = layout.instanceFields;
     staticFields = layout.staticFields;
-    staticInstance = staticShape.getFactory().create(this);
+    initializeStaticInstance(frame, topStack);
   }
 
-  public void safelyInitialize() {
-    // TODO
+  private void initializeStaticInstance(VirtualFrame frame, int topStack) {
+    staticInstance = staticShape.getFactory().create(this);
+    for (MethodSymbol method : getMethods()) {
+      if (method.getName().equals(".cctor")) {
+        callStaticConstructor(frame, topStack, method);
+        break;
+      }
+    }
+  }
+
+  @ExplodeLoop
+  private void callStaticConstructor(VirtualFrame frame, int topStack, MethodSymbol constructor) {
+    var callNode = new CALLNode(constructor, topStack);
+    callNode.execute(frame);
   }
   // endregion
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/NamedTypeSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/NamedTypeSymbol.java
@@ -375,8 +375,13 @@ public class NamedTypeSymbol extends TypeSymbol {
     initializeStaticInstance(frame, topStack);
   }
 
+  @ExplodeLoop
   private void initializeStaticInstance(VirtualFrame frame, int topStack) {
     staticInstance = staticShape.getFactory().create(this);
+    if (frame == null) {
+      return;
+    }
+
     for (MethodSymbol method : getMethods()) {
       if (method.getName().equals(".cctor")) {
         callStaticConstructor(frame, topStack, method);
@@ -385,7 +390,6 @@ public class NamedTypeSymbol extends TypeSymbol {
     }
   }
 
-  @ExplodeLoop
   private void callStaticConstructor(VirtualFrame frame, int topStack, MethodSymbol constructor) {
     var callNode = new CALLNode(constructor, topStack);
     callNode.execute(frame);

--- a/tests/src/test/java/com/vztekoverflow/cilostazol/tests/ObjectModelTests.java
+++ b/tests/src/test/java/com/vztekoverflow/cilostazol/tests/ObjectModelTests.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class ObjectManipulationTests extends TestBase {
+public class ObjectModelTests extends TestBase {
   @Test
   public void createObject() {
     var result =
@@ -66,6 +66,43 @@ public class ObjectManipulationTests extends TestBase {
                         }
                     }
                     """);
+
+    assertEquals(42, result.exitCode());
+  }
+
+  @Test
+  public void accessStaticFieldWithStaticConstructor() {
+    var result =
+        runTestFromCode(
+            """
+                    return TestClass.a;
+
+                    public class TestClass
+                    {
+                        public static int a;
+
+                        static TestClass()
+                        {
+                            a = 42;
+                        }
+                    }
+                    """);
+
+    assertEquals(42, result.exitCode());
+  }
+
+  @Test
+  public void accessStaticFieldAfterInitialization() {
+    var result =
+        runTestFromCode(
+            """
+                            return TestClass.a;
+
+                            public class TestClass
+                            {
+                                public static int a = 42;
+                            }
+                            """);
 
     assertEquals(42, result.exitCode());
   }
@@ -384,5 +421,25 @@ public class ObjectManipulationTests extends TestBase {
                         """);
 
     assertEquals(1, result.exitCode());
+  }
+
+  @Test
+  public void parentFieldAccess() {
+    var result =
+        runTestFromCode(
+            """
+                    TestStruct2 obj = new TestStruct2();
+                    obj.a = 42;
+                    return obj.a;
+
+                    public class TestStruct
+                    {
+                        public int a;
+                    }
+
+                    public class TestStruct2 : TestStruct { }
+                    """);
+
+    assertEquals(42, result.exitCode());
   }
 }


### PR DESCRIPTION
Call `.cctor.` when accessing a type's shape.
The call requires a frame and the top of the stack, since the constructor can evaluate general code. This requires these two parameters to be passed in from `CILMethodNode`.

Closes #113 