### PR TITLE
Interpreter: Memory transfers

### DIFF
--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -221,6 +221,8 @@ public class BytecodeInstructions {
   public static final int STARG = 0xFE0B;
   public static final int STLOC = 0xFE0E;
   public static final int INITOBJ = 0xFE15;
+  public static final int CPBLK = 0xFE17;
+  public static final int INITBLK = 0xFE18;
   public static final int SIZEOF = 0xFE1C;
 
   // Custom truffle instructions start here
@@ -491,6 +493,8 @@ public class BytecodeInstructions {
     def(CONV_R_UN, "conv.r.un", "o", 0);
 
     defPrefixed(SIZEOF, "sizeof", "otttt", 1);
+    defPrefixed(CPBLK, "cpblk", "o", -3);
+    defPrefixed(INITBLK, "initblk", "o", -3);
 
     def(TRUFFLE_NODE, "truffle.node", "oiiii", 0);
   }

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -224,6 +224,7 @@ public class BytecodeInstructions {
   public static final int LDLOC = 0xFE0C;
   public static final int LDLOCA = 0xFE0D;
   public static final int STLOC = 0xFE0E;
+  public static final int LOCALLOC = 0xFE0F;
   public static final int INITOBJ = 0xFE15;
   public static final int CPBLK = 0xFE17;
   public static final int INITBLK = 0xFE18;
@@ -503,6 +504,7 @@ public class BytecodeInstructions {
     defPrefixed(SIZEOF, "sizeof", "otttt", 1);
     defPrefixed(CPBLK, "cpblk", "o", -3);
     defPrefixed(INITBLK, "initblk", "o", -3);
+    defPrefixed(LOCALLOC, "localloc", "o", 0);
 
     def(TRUFFLE_NODE, "truffle.node", "oiiii", 0);
   }

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -216,6 +216,7 @@ public class BytecodeInstructions {
   public static final int CGT_UN = 0xFE03;
   public static final int CLT = 0xFE04;
   public static final int CLT_UN = 0xFE05;
+  public static final int STARG = 0xFE0B;
   public static final int INITOBJ = 0xFE15;
   public static final int SIZEOF = 0xFE1C;
 
@@ -483,6 +484,7 @@ public class BytecodeInstructions {
     def(CONV_R_UN, "conv.r.un", "o", 0);
 
     defPrefixed(SIZEOF, "sizeof", "otttt", 1);
+    defPrefixed(STARG, "starg", "oii", -1);
 
     def(TRUFFLE_NODE, "truffle.node", "oiiii", 0);
   }

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -219,6 +219,7 @@ public class BytecodeInstructions {
   public static final int LDARG = 0xFE09;
   public static final int LDARGA = 0xFE0A;
   public static final int STARG = 0xFE0B;
+  public static final int LDLOC = 0xFE0C;
   public static final int STLOC = 0xFE0E;
   public static final int INITOBJ = 0xFE15;
   public static final int CPBLK = 0xFE17;
@@ -326,6 +327,7 @@ public class BytecodeInstructions {
     def(LDLOC_3, "ldloc.3", "o", 1);
     def(LDLOC_S, "ldloc.s", "oi", 1);
     def(LDLOCA_S, "ldloca.s", "oi", 1);
+    defPrefixed(LDLOC, "ldloc", "oii", 1);
 
     def(LDTOKEN, "ldtoken", "otttt", 1);
 

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -220,6 +220,7 @@ public class BytecodeInstructions {
   public static final int LDARGA = 0xFE0A;
   public static final int STARG = 0xFE0B;
   public static final int LDLOC = 0xFE0C;
+  public static final int LDLOCA = 0xFE0D;
   public static final int STLOC = 0xFE0E;
   public static final int INITOBJ = 0xFE15;
   public static final int CPBLK = 0xFE17;
@@ -328,6 +329,7 @@ public class BytecodeInstructions {
     def(LDLOC_S, "ldloc.s", "oi", 1);
     def(LDLOCA_S, "ldloca.s", "oi", 1);
     defPrefixed(LDLOC, "ldloc", "oii", 1);
+    defPrefixed(LDLOCA, "ldloca", "oii", 1);
 
     def(LDTOKEN, "ldtoken", "otttt", 1);
 

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -508,7 +508,7 @@ public class BytecodeInstructions {
     defPrefixed(LOCALLOC, "localloc", "o", 0);
 
     def(MKREFANY, "mkrefany", "otttt", 0);
-    defPrefixed(REFANYVAL, "refanyval", "o", 0);
+    defPrefixed(REFANYVAL, "refanyval", "otttt", 0);
     defPrefixed(REFANYTYPE, "refanytype", "o", 0);
 
     def(TRUFFLE_NODE, "truffle.node", "oiiii", 0);

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -229,6 +229,7 @@ public class BytecodeInstructions {
   public static final int CPBLK = 0xFE17;
   public static final int INITBLK = 0xFE18;
   public static final int SIZEOF = 0xFE1C;
+  public static final int REFANYTYPE = 0xFE1D;
 
   // Custom truffle instructions start here
   // Allowed by III.1.2.1:
@@ -505,6 +506,10 @@ public class BytecodeInstructions {
     defPrefixed(CPBLK, "cpblk", "o", -3);
     defPrefixed(INITBLK, "initblk", "o", -3);
     defPrefixed(LOCALLOC, "localloc", "o", 0);
+
+    def(MKREFANY, "mkrefany", "otttt", 0);
+    defPrefixed(REFANYVAL, "refanyval", "o", 0);
+    defPrefixed(REFANYTYPE, "refanytype", "o", 0);
 
     def(TRUFFLE_NODE, "truffle.node", "oiiii", 0);
   }

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -217,6 +217,7 @@ public class BytecodeInstructions {
   public static final int CLT = 0xFE04;
   public static final int CLT_UN = 0xFE05;
   public static final int LDFTN = 0xFE06;
+  public static final int LDVIRTFTN = 0xFE07;
   public static final int LDARG = 0xFE09;
   public static final int LDARGA = 0xFE0A;
   public static final int STARG = 0xFE0B;
@@ -406,6 +407,7 @@ public class BytecodeInstructions {
 
     def(LDELEMA, "ldelema", "otttt", 0);
     defPrefixed(LDFTN, "ldftn", "otttt", 1);
+    defPrefixed(LDVIRTFTN, "ldvirtftn", "otttt", 0);
 
     def(DUP, "dup", "o", 1);
 

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -216,6 +216,7 @@ public class BytecodeInstructions {
   public static final int CGT_UN = 0xFE03;
   public static final int CLT = 0xFE04;
   public static final int CLT_UN = 0xFE05;
+  public static final int LDFTN = 0xFE06;
   public static final int LDARG = 0xFE09;
   public static final int LDARGA = 0xFE0A;
   public static final int STARG = 0xFE0B;
@@ -404,6 +405,7 @@ public class BytecodeInstructions {
     def(STELEM_REF, "stelem.ref", "o", -3);
 
     def(LDELEMA, "ldelema", "otttt", 0);
+    defPrefixed(LDFTN, "ldftn", "otttt", 1);
 
     def(DUP, "dup", "o", 1);
 

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -216,7 +216,10 @@ public class BytecodeInstructions {
   public static final int CGT_UN = 0xFE03;
   public static final int CLT = 0xFE04;
   public static final int CLT_UN = 0xFE05;
+  public static final int LDARG = 0xFE09;
+  public static final int LDARGA = 0xFE0A;
   public static final int STARG = 0xFE0B;
+  public static final int STLOC = 0xFE0E;
   public static final int INITOBJ = 0xFE15;
   public static final int SIZEOF = 0xFE1C;
 
@@ -329,6 +332,7 @@ public class BytecodeInstructions {
     def(STLOC_2, "stloc.2", "o", -1);
     def(STLOC_3, "stloc.3", "o", -1);
     def(STLOC_S, "stloc.s", "oi", -1);
+    defPrefixed(STLOC, "stloc", "oii", -1);
 
     def(LDARG_0, "ldarg.0", "o", 1);
     def(LDARG_1, "ldarg.1", "o", 1);
@@ -336,8 +340,11 @@ public class BytecodeInstructions {
     def(LDARG_3, "ldarg.3", "o", 1);
     def(LDARG_S, "ldarg.s", "oi", 1);
     def(LDARGA_S, "ldarga.s", "oi", 1);
+    defPrefixed(LDARG, "ldarg", "oii", 1);
+    defPrefixed(LDARGA, "ldarga", "oii", 1);
 
     def(STARG_S, "starg.s", "oi", -1);
+    defPrefixed(STARG, "starg", "oii", -1);
 
     def(LDIND_I1, "ldind.i1", "o", 0);
     def(LDIND_U1, "ldind.u1", "o", 0);
@@ -484,7 +491,6 @@ public class BytecodeInstructions {
     def(CONV_R_UN, "conv.r.un", "o", 0);
 
     defPrefixed(SIZEOF, "sizeof", "otttt", 1);
-    defPrefixed(STARG, "starg", "oii", -1);
 
     def(TRUFFLE_NODE, "truffle.node", "oiiii", 0);
   }

--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/cli/table/CLITablePtr.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/cli/table/CLITablePtr.java
@@ -16,6 +16,7 @@ public class CLITablePtr {
 
   private final byte tableId;
   private final int rowNo;
+  private final int token;
 
   /**
    * Create a new table pointer.
@@ -26,6 +27,18 @@ public class CLITablePtr {
   public CLITablePtr(byte tableId, int rowNo) {
     this.tableId = tableId;
     this.rowNo = rowNo;
+    this.token = -1;
+  }
+
+  /**
+   * Create a new table pointer.
+   *
+   * @param token the metadata token
+   */
+  public CLITablePtr(int token) {
+    this.tableId = (byte) (token >> 24);
+    this.rowNo = token & 0xFFFFFF;
+    this.token = token;
   }
 
   /**
@@ -35,9 +48,7 @@ public class CLITablePtr {
    * @return a table pointer pointer equivalent to the specified token
    */
   public static CLITablePtr fromToken(int token) {
-    byte table = (byte) (token >> 24);
-    int rowNo = token & 0xFFFFFF;
-    return new CLITablePtr(table, rowNo);
+    return new CLITablePtr(token);
   }
 
   /**
@@ -63,5 +74,9 @@ public class CLITablePtr {
 
   public boolean isEmpty() {
     return rowNo == 0;
+  }
+
+  public int getToken() {
+    return token;
   }
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -213,19 +213,17 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
               CILOSTAZOLFrame.getStartArgsOffset(getMethod()) + bytecodeBuffer.getImmUByte(pc),
               topStack);
           break;
+        case LDARG:
+            CILOSTAZOLFrame.copyStatic(
+                frame,
+                CILOSTAZOLFrame.getStartArgsOffset(getMethod()) + bytecodeBuffer.getImmUShort(pc),
+                topStack);
+            break;
         case LDARGA_S:
-          CILOSTAZOLFrame.putObject(
-              frame,
-              topStack,
-              getMethod()
-                  .getContext()
-                  .getAllocator()
-                  .createStackReference(
-                      SymbolResolver.resolveReference(
-                          ReferenceSymbol.ReferenceType.Argument, getMethod().getContext()),
-                      frame,
-                      bytecodeBuffer.getImmUByte(pc)
-                          + CILOSTAZOLFrame.getStartArgsOffset(getMethod())));
+          loadArgument(frame, bytecodeBuffer.getImmUByte(pc), topStack);
+          break;
+        case LDARGA:
+          loadArgument(frame, bytecodeBuffer.getImmUShort(pc), topStack);
           break;
 
           // Storing args
@@ -715,6 +713,20 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
       topStack += BytecodeInstructions.getStackEffect(curOpcode);
       pc = nextpc;
     }
+  }
+
+  private void loadArgument(VirtualFrame frame, int index, int topStack) {
+    CILOSTAZOLFrame.putObject(
+        frame,
+        topStack,
+        getMethod()
+            .getContext()
+            .getAllocator()
+            .createStackReference(
+                SymbolResolver.resolveReference(
+                    ReferenceSymbol.ReferenceType.Argument, getMethod().getContext()),
+                frame,
+                index + CILOSTAZOLFrame.getStartArgsOffset(getMethod())));
   }
 
   // region arithmetics

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -701,6 +701,11 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
               frame, topStack, curOpcode, getMethod().getOpCodeTypes()[pc], false, true);
           break;
 
+          // Unmanaged memory manipulation
+        case INITBLK:
+        case CPBLK:
+          throw new InterpreterException("Unmanaged memory manipulation not implemented");
+
         case TRUFFLE_NODE:
           topStack = nodes[bytecodeBuffer.getImmInt(pc)].execute(frame);
           break;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -175,19 +175,11 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
         case LDLOC:
           CILOSTAZOLFrame.copyStatic(frame, bytecodeBuffer.getImmUShort(pc), topStack);
           break;
-          // Storing to args
         case LDLOCA_S:
-          CILOSTAZOLFrame.putObject(
-              frame,
-              topStack,
-              getMethod()
-                  .getContext()
-                  .getAllocator()
-                  .createStackReference(
-                      SymbolResolver.resolveReference(
-                          ReferenceSymbol.ReferenceType.Local, getMethod().getContext()),
-                      frame,
-                      bytecodeBuffer.getImmUByte(pc)));
+          loadLocalIndirect(frame, bytecodeBuffer.getImmUByte(pc), topStack);
+          break;
+        case LDLOCA:
+          loadLocalIndirect(frame, bytecodeBuffer.getImmUShort(pc), topStack);
           break;
 
           // Loading args to top
@@ -711,20 +703,6 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
       topStack += BytecodeInstructions.getStackEffect(curOpcode);
       pc = nextpc;
     }
-  }
-
-  private void loadArgument(VirtualFrame frame, int index, int topStack) {
-    CILOSTAZOLFrame.putObject(
-        frame,
-        topStack,
-        getMethod()
-            .getContext()
-            .getAllocator()
-            .createStackReference(
-                SymbolResolver.resolveReference(
-                    ReferenceSymbol.ReferenceType.Argument, getMethod().getContext()),
-                frame,
-                index + CILOSTAZOLFrame.getStartArgsOffset(getMethod())));
   }
 
   // region arithmetics
@@ -1527,6 +1505,35 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
   private void duplicateSlot(VirtualFrame frame, int top) {
     CILOSTAZOLFrame.copyStatic(frame, top - 1, top);
   }
+
+  private void loadArgument(VirtualFrame frame, int index, int topStack) {
+    CILOSTAZOLFrame.putObject(
+        frame,
+        topStack,
+        getMethod()
+            .getContext()
+            .getAllocator()
+            .createStackReference(
+                SymbolResolver.resolveReference(
+                    ReferenceSymbol.ReferenceType.Argument, getMethod().getContext()),
+                frame,
+                index + CILOSTAZOLFrame.getStartArgsOffset(getMethod())));
+  }
+
+  private void loadLocalIndirect(VirtualFrame frame, int slot, int topStack) {
+    CILOSTAZOLFrame.putObject(
+        frame,
+        topStack,
+        getMethod()
+            .getContext()
+            .getAllocator()
+            .createStackReference(
+                SymbolResolver.resolveReference(
+                    ReferenceSymbol.ReferenceType.Local, getMethod().getContext()),
+                frame,
+                slot));
+  }
+
   // endregion
 
   private Object getReturnValue(VirtualFrame frame, int top) {

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -156,16 +156,10 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
         case STLOC_1:
         case STLOC_2:
         case STLOC_3:
-          CILOSTAZOLFrame.copyStatic(
-              frame,
-              topStack - 1,
-              curOpcode - STLOC_0 + CILOSTAZOLFrame.isInstantiable(getMethod()));
+          CILOSTAZOLFrame.copyStatic(frame, topStack - 1, curOpcode - STLOC_0);
           break;
         case STLOC_S:
-          CILOSTAZOLFrame.copyStatic(
-              frame,
-              topStack - 1,
-              bytecodeBuffer.getImmUByte(pc) + CILOSTAZOLFrame.isInstantiable(getMethod()));
+          CILOSTAZOLFrame.copyStatic(frame, topStack - 1, bytecodeBuffer.getImmUByte(pc));
           break;
 
           // Loading locals to top
@@ -173,15 +167,15 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
         case LDLOC_1:
         case LDLOC_2:
         case LDLOC_3:
-          CILOSTAZOLFrame.copyStatic(
-              frame, curOpcode - LDLOC_0 + CILOSTAZOLFrame.isInstantiable(getMethod()), topStack);
+          CILOSTAZOLFrame.copyStatic(frame, curOpcode - LDLOC_0, topStack);
           break;
         case LDLOC_S:
-          CILOSTAZOLFrame.copyStatic(
-              frame,
-              bytecodeBuffer.getImmUByte(pc) + CILOSTAZOLFrame.isInstantiable(getMethod()),
-              topStack);
+          CILOSTAZOLFrame.copyStatic(frame, bytecodeBuffer.getImmUByte(pc), topStack);
           break;
+        case LDLOC:
+          CILOSTAZOLFrame.copyStatic(frame, bytecodeBuffer.getImmUShort(pc), topStack);
+          break;
+          // Storing to args
         case LDLOCA_S:
           CILOSTAZOLFrame.putObject(
               frame,
@@ -193,8 +187,7 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
                       SymbolResolver.resolveReference(
                           ReferenceSymbol.ReferenceType.Local, getMethod().getContext()),
                       frame,
-                      bytecodeBuffer.getImmUByte(pc)
-                          + CILOSTAZOLFrame.isInstantiable(getMethod())));
+                      bytecodeBuffer.getImmUByte(pc)));
           break;
 
           // Loading args to top
@@ -214,11 +207,11 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
               topStack);
           break;
         case LDARG:
-            CILOSTAZOLFrame.copyStatic(
-                frame,
-                CILOSTAZOLFrame.getStartArgsOffset(getMethod()) + bytecodeBuffer.getImmUShort(pc),
-                topStack);
-            break;
+          CILOSTAZOLFrame.copyStatic(
+              frame,
+              CILOSTAZOLFrame.getStartArgsOffset(getMethod()) + bytecodeBuffer.getImmUShort(pc),
+              topStack);
+          break;
         case LDARGA_S:
           loadArgument(frame, bytecodeBuffer.getImmUByte(pc), topStack);
           break;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -689,6 +689,7 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
           // Unmanaged memory manipulation
         case INITBLK:
         case CPBLK:
+        case LDFTN:
           throw new InterpreterException("Unmanaged memory manipulation not implemented");
 
         case TRUFFLE_NODE:

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -691,7 +691,10 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
         case CPBLK:
         case LDFTN:
         case LDVIRTFTN:
-          throw new InterpreterException("Unmanaged memory manipulation not implemented");
+        case LOCALLOC:
+        case LDTOKEN:
+          throw new InterpreterException(
+              "Unmanaged memory manipulation not implemented for opcode " + curOpcode);
 
         case TRUFFLE_NODE:
           topStack = nodes[bytecodeBuffer.getImmInt(pc)].execute(frame);

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -690,6 +690,7 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
         case INITBLK:
         case CPBLK:
         case LDFTN:
+        case LDVIRTFTN:
           throw new InterpreterException("Unmanaged memory manipulation not implemented");
 
         case TRUFFLE_NODE:

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -290,6 +290,13 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
         case SIZEOF:
           getSize(frame, topStack, bytecodeBuffer.getImmToken(pc));
           break;
+        case MKREFANY:
+          makeTypedRef(frame, topStack, bytecodeBuffer.getImmToken(pc));
+          break;
+        case REFANYTYPE:
+          break;
+        case REFANYVAL:
+          break;
 
           // Branching
         case BEQ:
@@ -1481,11 +1488,25 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
       }
     }
   }
-  // endregion
 
   private void storeIndirectNative(VirtualFrame frame, int top) {
     storeIndirectInt(frame, top);
   }
+
+  private void makeTypedRef(VirtualFrame frame, int top, CLITablePtr token) {
+    StaticObject reference = CILOSTAZOLFrame.popObject(frame, top - 1);
+    StaticObject typedReference =
+        getMethod()
+            .getContext()
+            .getAllocator()
+            .createTypedReference(
+                SymbolResolver.resolveReference(
+                    ReferenceSymbol.ReferenceType.Typed, getMethod().getContext()),
+                reference,
+                token);
+    CILOSTAZOLFrame.putObject(frame, top - 1, typedReference);
+  }
+  // endregion
 
   // region other helpers
   private void pop(VirtualFrame frame, int top, StaticOpCodeAnalyser.OpCodeType type) {

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -111,7 +111,7 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
           pop(frame, topStack, getMethod().getOpCodeTypes()[pc]);
           break;
         case DUP:
-          duplicateSlot(frame, topStack - 1);
+          duplicateSlot(frame, topStack);
           break;
 
           // Loading on top of the stack
@@ -227,6 +227,19 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
                       bytecodeBuffer.getImmUByte(pc)
                           + CILOSTAZOLFrame.getStartArgsOffset(getMethod())));
           break;
+
+          // Storing args
+        case STARG_S:
+          CILOSTAZOLFrame.moveValueStatic(
+              frame,
+              topStack - 1,
+              CILOSTAZOLFrame.getStartArgsOffset(getMethod()) + bytecodeBuffer.getImmUByte(pc));
+          break;
+        case STARG:
+          CILOSTAZOLFrame.moveValueStatic(
+              frame,
+              topStack - 1,
+              CILOSTAZOLFrame.getStartArgsOffset(getMethod()) + bytecodeBuffer.getImmUShort(pc));
 
           // Loading fields
         case LDFLD:
@@ -1502,7 +1515,7 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
   }
 
   private void duplicateSlot(VirtualFrame frame, int top) {
-    CILOSTAZOLFrame.copyStatic(frame, top, top + 1);
+    CILOSTAZOLFrame.copyStatic(frame, top - 1, top);
   }
   // endregion
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILOSTAZOLFrame.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILOSTAZOLFrame.java
@@ -331,6 +331,12 @@ public final class CILOSTAZOLFrame {
     frame.copyStatic(sourceSlot, destSlot);
   }
 
+  public static void moveValueStatic(Frame frame, int sourceSlot, int destSlot) {
+    assert sourceSlot >= 0 && destSlot >= 0;
+    frame.copyStatic(sourceSlot, destSlot);
+    frame.clearStatic(sourceSlot);
+  }
+
   // region stack types
   public enum StackType {
     Object,

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/context/CILOSTAZOLContext.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/context/CILOSTAZOLContext.java
@@ -50,7 +50,6 @@ public class CILOSTAZOLContext {
 
   @CompilerDirectives.CompilationFinal
   private StaticShape<StaticObject.StaticObjectFactory> typedReferenceShape;
-  
   @CompilerDirectives.CompilationFinal private StaticProperty typedReferenceInnerRefProperty;
   @CompilerDirectives.CompilationFinal private StaticProperty typedReferenceTypeTokenProperty;
   // region SOM

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/context/CILOSTAZOLContext.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/context/CILOSTAZOLContext.java
@@ -50,6 +50,7 @@ public class CILOSTAZOLContext {
 
   @CompilerDirectives.CompilationFinal
   private StaticShape<StaticObject.StaticObjectFactory> typedReferenceShape;
+
   @CompilerDirectives.CompilationFinal private StaticProperty typedReferenceInnerRefProperty;
   @CompilerDirectives.CompilationFinal private StaticProperty typedReferenceTypeTokenProperty;
   // region SOM

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/objectmodel/GuestAllocator.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/objectmodel/GuestAllocator.java
@@ -6,6 +6,7 @@ import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.AllocationReporter;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.vztekoverflow.cil.parser.cli.table.CLITablePtr;
 import com.vztekoverflow.cilostazol.CILOSTAZOLLanguage;
 import com.vztekoverflow.cilostazol.exceptions.InstantiationError;
 import com.vztekoverflow.cilostazol.exceptions.InstantiationException;
@@ -298,6 +299,15 @@ public final class GuestAllocator {
         reference.getContext().getArrayElementReferenceShape().getFactory().create(reference);
     reference.getContext().getArrayElementReferenceArrayProperty().setObject(newRef, array);
     reference.getContext().getArrayElementReferenceIndexProperty().setInt(newRef, elemIndex);
+    return newRef;
+  }
+
+  public StaticObject createTypedReference(
+      ReferenceSymbol referenceSymbol, StaticObject reference, CLITablePtr token) {
+    StaticObject newRef =
+        referenceSymbol.getContext().getTypedReferenceShape().getFactory().create(referenceSymbol);
+    referenceSymbol.getContext().getTypedReferenceInnerRefProperty().setObject(newRef, reference);
+    referenceSymbol.getContext().getTypedReferenceTypeTokenProperty().setObject(newRef, token);
     return newRef;
   }
   // endregion

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/other/SymbolResolver.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/other/SymbolResolver.java
@@ -234,8 +234,7 @@ public final class SymbolResolver {
     var resolutionScope = row.getResolutionScopeTablePtr();
     AssemblyIdentity identity =
         switch (resolutionScope.getTableId()) {
-          case CLITableConstants.CLI_TABLE_MODULE -> module.getDefiningFile().getAssemblyIdentity();
-          case CLITableConstants.CLI_TABLE_MODULE_REF -> module
+          case CLITableConstants.CLI_TABLE_MODULE, CLITableConstants.CLI_TABLE_MODULE_REF -> module
               .getDefiningFile()
               .getAssemblyIdentity();
           case CLITableConstants.CLI_TABLE_ASSEMBLY_REF -> AssemblyIdentity.fromAssemblyRefRow(

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/ReferenceSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/ReferenceSymbol.java
@@ -8,7 +8,8 @@ public final class ReferenceSymbol extends TypeSymbol {
     Local,
     Argument,
     Field,
-    ArrayElement
+    ArrayElement,
+    Typed
   }
 
   private final ReferenceType type;
@@ -37,6 +38,10 @@ public final class ReferenceSymbol extends TypeSymbol {
 
     public static ReferenceSymbol createArrayElemReference() {
       return new ReferenceSymbol(ReferenceType.ArrayElement);
+    }
+
+    public static ReferenceSymbol createTypedReference() {
+      return new ReferenceSymbol(ReferenceType.Typed);
     }
   }
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -571,6 +571,9 @@ public class StaticOpCodeAnalyser {
         clear(stack, topStack - 1);
         clear(stack, topStack - 2);
         break;
+      case LDFTN:
+        replace(stack, topStack, ManagedPointer);
+        break;
       case TRUFFLE_NODE:
         // TODO
         break;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -102,9 +102,9 @@ public class StaticOpCodeAnalyser {
       case STLOC_2:
       case STLOC_3:
       case STLOC_S:
-        // case STLOC: //we do not track this opcode
+      case STLOC:
       case STARG_S:
-        // case STARG: //we do not track this opcode
+      case STARG:
         setTypeByStack(types, stack, topStack, pc, curOpcode);
         clear(stack, topStack);
         break;
@@ -117,12 +117,14 @@ public class StaticOpCodeAnalyser {
         break;
 
       case LDARG_S:
-        // case LDARG: //we do not track this opcode
         handleArg(parameters, stack, topStack, bytecodeBuffer.getImmUByte(pc));
+        break;
+      case LDARG:
+        handleArg(parameters, stack, topStack, bytecodeBuffer.getImmUShort(pc));
         break;
 
       case LDARGA_S:
-        // case LDARGA: //we do not track this opcode
+      case LDARGA:
         push(stack, topStack, StackType.ManagedPointer);
         break;
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -141,7 +141,7 @@ public class StaticOpCodeAnalyser {
         break;
 
       case LDLOCA_S:
-        // case LDLOCA: //we do not track this opcode
+      case LDLOCA:
         push(stack, topStack, StackType.ManagedPointer);
         break;
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -534,6 +534,9 @@ public class StaticOpCodeAnalyser {
           replace(stack, topStack, ManagedPointer);
           break;
         }
+      case REFANYTYPE:
+        push(stack, topStack, Int32);
+        break;
       case CKFINITE:
         setTypeByStack(types, stack, topStack, pc, curOpcode);
         break;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -572,6 +572,9 @@ public class StaticOpCodeAnalyser {
         clear(stack, topStack - 2);
         break;
       case LDFTN:
+        push(stack, topStack, ManagedPointer);
+        break;
+      case LDVIRTFTN:
         replace(stack, topStack, ManagedPointer);
         break;
       case TRUFFLE_NODE:

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -136,7 +136,7 @@ public class StaticOpCodeAnalyser {
         break;
 
       case LDLOC_S:
-        // case LDLOC: //we do not track this opcode
+      case LDLOC:
         handleLoc(locals, stack, topStack, bytecodeBuffer.getImmUByte(pc));
         break;
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -273,7 +273,7 @@ public class StaticOpCodeAnalyser {
         replace(stack, topStack, Int32);
         break;
       case LDIND_I8:
-        // case LDIND_U8: //we do not track this opcode
+        // LDIND_U8 has the same opcode and logic
         replace(stack, topStack, Int64);
         break;
       case LDIND_I:

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -535,7 +535,7 @@ public class StaticOpCodeAnalyser {
           break;
         }
       case REFANYTYPE:
-        push(stack, topStack, Int32);
+        replace(stack, topStack, Int32);
         break;
       case CKFINITE:
         setTypeByStack(types, stack, topStack, pc, curOpcode);

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -574,8 +574,12 @@ public class StaticOpCodeAnalyser {
       case LDFTN:
         push(stack, topStack, ManagedPointer);
         break;
+      case LOCALLOC:
       case LDVIRTFTN:
         replace(stack, topStack, ManagedPointer);
+        break;
+      case LDTOKEN:
+        push(stack, topStack, Object);
         break;
       case TRUFFLE_NODE:
         // TODO

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -565,6 +565,12 @@ public class StaticOpCodeAnalyser {
       case SIZEOF:
         push(stack, topStack, Int32);
         break;
+      case CPBLK:
+      case INITBLK:
+        clear(stack, topStack);
+        clear(stack, topStack - 1);
+        clear(stack, topStack - 2);
+        break;
       case TRUFFLE_NODE:
         // TODO
         break;

--- a/tests/src/test/java/com/vztekoverflow/cilostazol/tests/MemoryTransferTests.java
+++ b/tests/src/test/java/com/vztekoverflow/cilostazol/tests/MemoryTransferTests.java
@@ -1,0 +1,24 @@
+package com.vztekoverflow.cilostazol.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class MemoryTransferTests extends TestBase {
+  @Test
+  public void storeArg() {
+    var result =
+        runTestFromCode(
+            """
+                        return Foo(1);
+
+                        static int Foo(int a)
+                        {
+                            a = 42;
+                            return a;
+                        }
+                        """);
+
+    assertEquals(42, result.exitCode());
+  }
+}


### PR DESCRIPTION
Interpreter: Memory transfers

Implements opcodes for safe memory transfers.
Certain operations in unsafe context throw an exception due to being 
unsupported.
A new reference type was added - `Typed`. Typed references wrap 
existing references with a `CLITablePtr` type token.

Closes #78 