### PR TITLE
Interpreter: Add custom method implementation support

### DIFF
--- a/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
+++ b/cil-parser/src/main/java/com/vztekoverflow/cil/parser/bytecode/BytecodeInstructions.java
@@ -383,7 +383,7 @@ public class BytecodeInstructions {
     def(LDSFLD, "ldsfld", "otttt", 1);
     def(STSFLD, "stsfld", "otttt", -1);
     def(LDFLDA, "ldflda", "otttt", 0);
-    def(LDSFLDA, "ldsfdla", "otttt", 0);
+    def(LDSFLDA, "ldsfdla", "otttt", 1);
 
     def(LDELEM, "ldelem", "otttt", 0);
     def(LDELEM_I1, "ldelem.i1", "o", -1);

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -1000,11 +1000,13 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
   private void doNeg(VirtualFrame frame, int top, StaticOpCodeAnalyser.OpCodeType type) {
     switch (type) {
       case Int32 -> CILOSTAZOLFrame.putInt32(
-          frame, top - 1, CILOSTAZOLFrame.popInt32(frame, top - 1));
+          frame, top - 1, -CILOSTAZOLFrame.popInt32(frame, top - 1));
       case Int64 -> CILOSTAZOLFrame.putInt64(
-          frame, top - 1, CILOSTAZOLFrame.popInt64(frame, top - 1));
+          frame, top - 1, -CILOSTAZOLFrame.popInt64(frame, top - 1));
       case NativeInt -> CILOSTAZOLFrame.putNativeInt(
-          frame, top - 1, CILOSTAZOLFrame.popNativeInt(frame, top - 1));
+          frame, top - 1, -CILOSTAZOLFrame.popNativeInt(frame, top - 1));
+      case NativeFloat -> CILOSTAZOLFrame.putNativeFloat(
+          frame, top - 1, -CILOSTAZOLFrame.popNativeFloat(frame, top - 1));
       default -> throw new InterpreterException();
     }
   }
@@ -1897,6 +1899,10 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
         boolean value = field.getBoolean(object);
         CILOSTAZOLFrame.putInt32(frame, top - 1, value ? 1 : 0);
       }
+      case Byte -> {
+        byte value = field.getByte(object);
+        CILOSTAZOLFrame.putInt32(frame, top - 1, value);
+      }
       case Char -> {
         char value = field.getChar(object);
         CILOSTAZOLFrame.putInt32(frame, top - 1, value);
@@ -1954,6 +1960,10 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
       case Boolean -> {
         int value = CILOSTAZOLFrame.popInt32(frame, top - 1);
         field.setBoolean(object, value != 0);
+      }
+      case Byte -> {
+        int value = CILOSTAZOLFrame.popInt32(frame, top - 1);
+        field.setByte(object, (byte) value);
       }
       case Short -> {
         int value = CILOSTAZOLFrame.popInt32(frame, top - 1);

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILMethodNode.java
@@ -39,7 +39,7 @@ public class CILMethodNode extends CILNodeBase implements BytecodeOSRNode {
   @Children private NodeizedNodeBase[] nodes = new NodeizedNodeBase[0];
   @CompilerDirectives.CompilationFinal private Object osrMetadata;
 
-  private CILMethodNode(MethodSymbol method) {
+  CILMethodNode(MethodSymbol method) {
     this.method = method;
     cil = method.getCIL();
     frameDescriptor =

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILOSTAZOLRootNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILOSTAZOLRootNode.java
@@ -16,7 +16,12 @@ public final class CILOSTAZOLRootNode extends RootNode {
   }
 
   public static CILOSTAZOLRootNode create(MethodSymbol method) {
-    final CILMethodNode node = CILMethodNode.create(method);
+    final CILMethodNode node;
+    if (method.isInternalCall()) {
+      node = CILRuntimeSpecificMethodNode.create(method);
+    } else {
+      node = CILMethodNode.create(method);
+    }
     return new CILOSTAZOLRootNode(node.getFrameDescriptor(), node);
   }
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILRuntimeSpecificMethodNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/CILRuntimeSpecificMethodNode.java
@@ -1,0 +1,27 @@
+package com.vztekoverflow.cilostazol.nodes;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.vztekoverflow.cilostazol.runtime.symbols.MethodSymbol;
+import java.util.function.Function;
+
+public class CILRuntimeSpecificMethodNode extends CILMethodNode {
+
+  Function<VirtualFrame, Object> implementation;
+
+  public CILRuntimeSpecificMethodNode(MethodSymbol method) {
+    super(method);
+    implementation = RuntimeSpecificMethodImplementations.getImplementation(method.toString());
+    if (implementation == null) {
+      throw new IllegalArgumentException("No implementation for " + method);
+    }
+  }
+
+  public static CILRuntimeSpecificMethodNode create(MethodSymbol method) {
+    return new CILRuntimeSpecificMethodNode(method);
+  }
+
+  @Override
+  public Object execute(VirtualFrame frame) {
+    return implementation.apply(frame);
+  }
+}

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/RuntimeSpecificMethodImplementations.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/RuntimeSpecificMethodImplementations.java
@@ -1,0 +1,21 @@
+package com.vztekoverflow.cilostazol.nodes;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class RuntimeSpecificMethodImplementations {
+  private static final Map<String, Function<VirtualFrame, Object>> methodImplementations =
+      Map.of(
+          "System::Double System::Math::Sqrt(System::Double)",
+          RuntimeSpecificMethodImplementations::Sqrt);
+
+  public static Function<VirtualFrame, Object> getImplementation(String methodIdentifier) {
+    return methodImplementations.get(methodIdentifier);
+  }
+
+  private static Object Sqrt(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.sqrt(d);
+  }
+}

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/RuntimeSpecificMethodImplementations.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/RuntimeSpecificMethodImplementations.java
@@ -1,21 +1,91 @@
 package com.vztekoverflow.cilostazol.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.vztekoverflow.cilostazol.nodes.internal.MathMethodImplementations;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
 public final class RuntimeSpecificMethodImplementations {
-  private static final Map<String, Function<VirtualFrame, Object>> methodImplementations =
-      Map.of(
-          "System::Double System::Math::Sqrt(System::Double)",
-          RuntimeSpecificMethodImplementations::Sqrt);
+  public static final Map<String, Function<VirtualFrame, Object>> methodImplementations =
+      new HashMap<>() {
+        {
+          put(
+              "System::Double System::Math::Acos(System::Double)",
+              MathMethodImplementations::MathAcos);
+          put(
+              "System::Double System::Math::Acosh(System::Double)",
+              MathMethodImplementations::MathAcosh);
+          put(
+              "System::Double System::Math::Asin(System::Double)",
+              MathMethodImplementations::MathAsin);
+          put(
+              "System::Double System::Math::Asinh(System::Double)",
+              MathMethodImplementations::MathAsinh);
+          put(
+              "System::Double System::Math::Atan(System::Double)",
+              MathMethodImplementations::MathAtan);
+          put(
+              "System::Double System::Math::Atanh(System::Double)",
+              MathMethodImplementations::MathAtanh);
+          put(
+              "System::Double System::Math::Atan2(System::Double,System::Double)",
+              MathMethodImplementations::MathAtan2);
+          put(
+              "System::Double System::Math::Cbrt(System::Double)",
+              MathMethodImplementations::MathCbrt);
+          put(
+              "System::Double System::Math::Ceiling(System::Double)",
+              MathMethodImplementations::MathCeiling);
+          put(
+              "System::Double System::Math::Cos(System::Double)",
+              MathMethodImplementations::MathCos);
+          put(
+              "System::Double System::Math::Cosh(System::Double)",
+              MathMethodImplementations::MathCosh);
+          put(
+              "System::Double System::Math::Exp(System::Double)",
+              MathMethodImplementations::MathExp);
+          put(
+              "System::Double System::Math::Floor(System::Double)",
+              MathMethodImplementations::MathFloor);
+          put(
+              "System::Double System::Math::Log(System::Double)",
+              MathMethodImplementations::MathLog);
+          put(
+              "System::Double System::Math::Log(System::Double,System::Double)",
+              MathMethodImplementations::MathLog2);
+          put(
+              "System::Double System::Math::Log10(System::Double)",
+              MathMethodImplementations::MathLog10);
+          put(
+              "System::Double System::Math::Pow(System::Double,System::Double)",
+              MathMethodImplementations::MathPow);
+          put(
+              "System::Double System::Math::Sin(System::Double)",
+              MathMethodImplementations::MathSin);
+          put(
+              "System::Double System::Math::Sinh(System::Double)",
+              MathMethodImplementations::MathSinh);
+          put(
+              "System::Double System::Math::Sqrt(System::Double)",
+              MathMethodImplementations::MathSqrt);
+          put(
+              "System::Double System::Math::Tan(System::Double)",
+              MathMethodImplementations::MathTan);
+          put(
+              "System::Double System::Math::Tanh(System::Double)",
+              MathMethodImplementations::MathTanh);
+          put(
+              "System::Double System::Math::ModF(System::Double,System::Double)",
+              MathMethodImplementations::MathModF);
+          put(
+              "System::Double[] System::Math::SinCos(System::Double,System::Double)",
+              MathMethodImplementations::MathSinCos);
+        }
+      };
 
   public static Function<VirtualFrame, Object> getImplementation(String methodIdentifier) {
     return methodImplementations.get(methodIdentifier);
-  }
-
-  private static Object Sqrt(VirtualFrame frame) {
-    double d = (Double) frame.getArguments()[0];
-    return Math.sqrt(d);
   }
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/RuntimeSpecificMethodImplementations.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/RuntimeSpecificMethodImplementations.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 public final class RuntimeSpecificMethodImplementations {
-  public static final Map<String, Function<VirtualFrame, Object>> methodImplementations =
+  private static final Map<String, Function<VirtualFrame, Object>> methodImplementations =
       new HashMap<>() {
         {
           put(
@@ -87,5 +87,9 @@ public final class RuntimeSpecificMethodImplementations {
 
   public static Function<VirtualFrame, Object> getImplementation(String methodIdentifier) {
     return methodImplementations.get(methodIdentifier);
+  }
+
+  public static boolean hasCustomImplementation(String methodIdentifier) {
+    return methodImplementations.containsKey(methodIdentifier);
   }
 }

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/internal/MathMethodImplementations.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/internal/MathMethodImplementations.java
@@ -1,0 +1,135 @@
+package com.vztekoverflow.cilostazol.nodes.internal;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+
+public final class MathMethodImplementations {
+  public static Object MathAcos(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.acos(d);
+  }
+
+  public static Object MathAcosh(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.log(d + Math.sqrt(d * d - 1));
+  }
+
+  public static Object MathAsin(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.asin(d);
+  }
+
+  public static Object MathAsinh(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.log(d + Math.sqrt(d * d + 1));
+  }
+
+  public static Object MathAtan(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.atan(d);
+  }
+
+  public static Object MathAtanh(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.log((1 + d) / (1 - d)) / 2;
+  }
+
+  public static Object MathAtan2(VirtualFrame frame) {
+    double y = (Double) frame.getArguments()[0];
+    double x = (Double) frame.getArguments()[1];
+    return Math.atan2(y, x);
+  }
+
+  public static Object MathCbrt(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.cbrt(d);
+  }
+
+  public static Object MathCeiling(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.ceil(d);
+  }
+
+  public static Object MathCos(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.cos(d);
+  }
+
+  public static Object MathCosh(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.cosh(d);
+  }
+
+  public static Object MathExp(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.exp(d);
+  }
+
+  public static Object MathFloor(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.floor(d);
+  }
+
+  public static Object MathFusedMultiplyAdd(VirtualFrame frame) {
+    double x = (Double) frame.getArguments()[0];
+    double y = (Double) frame.getArguments()[1];
+    double z = (Double) frame.getArguments()[2];
+    return Math.fma(x, y, z);
+  }
+
+  public static Object MathLog(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.log(d);
+  }
+
+  public static Object MathLog10(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.log10(d);
+  }
+
+  public static Object MathLog2(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.log(d) / Math.log(2);
+  }
+
+  public static Object MathPow(VirtualFrame frame) {
+    double x = (Double) frame.getArguments()[0];
+    double y = (Double) frame.getArguments()[1];
+    return Math.pow(x, y);
+  }
+
+  public static Object MathSin(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.sin(d);
+  }
+
+  public static Object MathSinh(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.sinh(d);
+  }
+
+  public static Object MathSqrt(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.sqrt(d);
+  }
+
+  public static Object MathTan(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.tan(d);
+  }
+
+  public static Object MathTanh(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return Math.tanh(d);
+  }
+
+  public static Object MathModF(VirtualFrame frame) {
+    double x = (Double) frame.getArguments()[0];
+    double y = (Double) frame.getArguments()[1];
+    return Math.IEEEremainder(x, y);
+  }
+
+  public static Object MathSinCos(VirtualFrame frame) {
+    double d = (Double) frame.getArguments()[0];
+    return new double[] {Math.sin(d), Math.cos(d)};
+  }
+}

--- a/language/src/main/java/com/vztekoverflow/cilostazol/nodes/nodeized/CALLNode.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/nodes/nodeized/CALLNode.java
@@ -28,10 +28,10 @@ public final class CALLNode extends NodeizedNodeBase {
 
     if (method.hasReturnValue()) {
       CILOSTAZOLFrame.put(frame, returnValue, returnStackTop, method.getReturnType().getType());
+      return returnStackTop + 1;
     }
 
-    // +1 for return value
-    return returnStackTop + 1;
+    return returnStackTop;
   }
 
   @NotNull

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/other/SymbolResolver.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/other/SymbolResolver.java
@@ -374,6 +374,7 @@ public final class SymbolResolver {
           module);
       case CLITableConstants.CLI_TABLE_METHOD_SPEC -> resolveMethod(
           module.getDefiningFile().getTableHeads().getMethodSpecTableHead().skip(row),
+          methodTypeArgs,
           typeTypeArgs,
           module);
       default -> throw new CILParserException();
@@ -447,17 +448,19 @@ public final class SymbolResolver {
   }
 
   public static ClassMember<MethodSymbol> resolveMethod(
-      CLIMethodSpecTableRow row, TypeSymbol[] typeTypeArgs, ModuleSymbol module) {
+      CLIMethodSpecTableRow row,
+      TypeSymbol[] methodTypeArgs,
+      TypeSymbol[] typeTypeArgs,
+      ModuleSymbol module) {
     var signature =
         MethodSpecSig.read(
             new SignatureReader(
                 row.getInstantiationHeapPtr().read(module.getDefiningFile().getBlobHeap())));
     TypeSymbol[] typeArgs = new TypeSymbol[signature.getGenArgCount()];
     for (int i = 0; i < typeArgs.length; i++) {
-      typeArgs[i] =
-          resolveType(signature.getTypeArgs()[i], new TypeSymbol[0], typeTypeArgs, module);
+      typeArgs[i] = resolveType(signature.getTypeArgs()[i], methodTypeArgs, typeTypeArgs, module);
     }
-    var genMethod = resolveMethod(row.getMethodTablePtr(), new TypeSymbol[0], typeTypeArgs, module);
+    var genMethod = resolveMethod(row.getMethodTablePtr(), methodTypeArgs, typeTypeArgs, module);
 
     return new ClassMember<MethodSymbol>(
         genMethod.symbol, resolveMethod(genMethod.member, typeArgs, module.getContext()));

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/MethodSymbol.java
@@ -15,6 +15,7 @@ import com.vztekoverflow.cil.parser.cli.table.generated.CLIParamTableRow;
 import com.vztekoverflow.cilostazol.CILOSTAZOLBundle;
 import com.vztekoverflow.cilostazol.exceptions.TypeSystemException;
 import com.vztekoverflow.cilostazol.nodes.CILOSTAZOLRootNode;
+import com.vztekoverflow.cilostazol.nodes.RuntimeSpecificMethodImplementations;
 import com.vztekoverflow.cilostazol.runtime.context.ContextProviderImpl;
 import com.vztekoverflow.cilostazol.staticanalysis.StaticOpCodeAnalyser;
 import java.util.Arrays;
@@ -179,7 +180,9 @@ public class MethodSymbol extends Symbol {
         + "::"
         + getName()
         + "("
-        + Arrays.stream(getParameterTypes()).map(TypeSymbol::toString).collect(Collectors.joining())
+        + Arrays.stream(getParameters())
+            .map(ParameterSymbol::toString)
+            .collect(Collectors.joining())
         + ")";
   }
 
@@ -382,6 +385,24 @@ public class MethodSymbol extends Symbol {
               typeParameters,
               definingTypeTypeParams,
               definingType.getDefiningModule());
+
+      if (!isInternalCall) {
+        String methodIdentifier =
+            returnSymbol
+                + " "
+                + definingType
+                + "::"
+                + name
+                + "("
+                + Arrays.stream(parameters)
+                    .map(ParameterSymbol::toString)
+                    .collect(Collectors.joining())
+                + ")";
+
+        if (RuntimeSpecificMethodImplementations.hasCustomImplementation(methodIdentifier)) {
+          isInternalCall = true;
+        }
+      }
 
       return new MethodSymbol(
           name,

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/ParameterSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/ParameterSymbol.java
@@ -42,6 +42,15 @@ public final class ParameterSymbol extends Symbol {
     return type;
   }
 
+  @Override
+  public String toString() {
+    if (type == null) {
+      return "null";
+    }
+
+    return type.toString();
+  }
+
   public static final class ParameterSymbolFactory {
     public static ParameterSymbol create(
         ParamSig paramSig,

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/ReturnSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/ReturnSymbol.java
@@ -16,6 +16,10 @@ public final class ReturnSymbol extends Symbol {
 
   @Override
   public String toString() {
+    if (type == null) {
+      return "null";
+    }
+
     return type.toString();
   }
 

--- a/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/SubstitutedMethodSymbol.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/runtime/symbols/SubstitutedMethodSymbol.java
@@ -26,7 +26,8 @@ public class SubstitutedMethodSymbol extends MethodSymbol {
         createHandlers(constructedFrom.exceptionHandlers, map),
         constructedFrom.cil,
         constructedFrom.maxStack,
-        constructedFrom.methodHeaderFlags);
+        constructedFrom.methodHeaderFlags,
+        constructedFrom.isInternalCall);
     this.definition = definition;
     this.constructedFrom = constructedFrom;
     this.map = map;

--- a/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
+++ b/language/src/main/java/com/vztekoverflow/cilostazol/staticanalysis/StaticOpCodeAnalyser.java
@@ -760,7 +760,7 @@ public class StaticOpCodeAnalyser {
       }
       case NativeFloat -> {
         types[pc] = OpCodeType.NativeFloat;
-        replace(stack, topStack, StackType.NativeInt);
+        replace(stack, topStack, StackType.NativeFloat);
       }
       default -> ThrowInvalidCLI(
           CILOSTAZOLBundle.message(

--- a/tests/src/test/java/com/vztekoverflow/cilostazol/tests/BenchmarkValidityTests.java
+++ b/tests/src/test/java/com/vztekoverflow/cilostazol/tests/BenchmarkValidityTests.java
@@ -1,0 +1,163 @@
+package com.vztekoverflow.cilostazol.tests;
+
+import org.junit.jupiter.api.Test;
+
+public class BenchmarkValidityTests extends TestBase {
+  @Test
+  public void nBody() {
+    var result =
+        runTestFromCode(
+            """
+                namespace nbody
+                {
+                    /*  The Computer Language Benchmarks Game
+                        https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+
+                        contributed by Isaac Gouy
+                        modified by Robert F. Tobler
+                        modified by Eric P. Nusbaum
+                    */
+
+                    using System;
+
+                    public class NBody
+                    {
+                        public static void Main(String[] args)
+                        {
+                                int n = args.Length > 0 ? Int32.Parse(args[0]) : 10000;
+                                NBodySystem bodies = new NBodySystem();
+                                Console.WriteLine("{0:f9}", bodies.Energy());
+                                for (int i = 0; i < n; i++) bodies.Advance(0.01);
+                                Console.WriteLine("{0:f9}", bodies.Energy());
+                        }
+                    }
+
+                    public class Body { public double x, y, z, vx, vy, vz, mass; }
+                   \s
+
+                    public class NBodySystem
+                    {
+                        private Body[] _bodies;
+                        private Body[] _pairL;
+                        private Body[] _pairR;
+                        private byte bodyCount = 5;
+
+                        const double Pi = 3.141592653589793;
+                        const double Solarmass = 4 * Pi * Pi;
+                        const double DaysPeryear = 365.24;
+
+                        public NBodySystem()
+                        {
+                            _bodies = new[]
+                            {
+                                new Body()
+                                {
+                                    // Sun
+                                    mass = Solarmass,
+                                },
+                                new Body()
+                                {
+                                    // Jupiter
+                                    x = 4.84143144246472090e+00,
+                                    y = -1.16032004402742839e+00,
+                                    z = -1.03622044471123109e-01,
+                                    vx = 1.66007664274403694e-03*DaysPeryear,
+                                    vy = 7.69901118419740425e-03*DaysPeryear,
+                                    vz = -6.90460016972063023e-05*DaysPeryear,
+                                    mass = 9.54791938424326609e-04*Solarmass,
+                                },
+                                new Body()
+                                {
+                                    // Saturn
+                                    x = 8.34336671824457987e+00,
+                                    y = 4.12479856412430479e+00,
+                                    z = -4.03523417114321381e-01,
+                                    vx = -2.76742510726862411e-03*DaysPeryear,
+                                    vy = 4.99852801234917238e-03*DaysPeryear,
+                                    vz = 2.30417297573763929e-05*DaysPeryear,
+                                    mass = 2.85885980666130812e-04*Solarmass,
+                                },
+                                new Body()
+                                {
+                                    // Uranus
+                                    x = 1.28943695621391310e+01,
+                                    y = -1.51111514016986312e+01,
+                                    z = -2.23307578892655734e-01,
+                                    vx = 2.96460137564761618e-03*DaysPeryear,
+                                    vy = 2.37847173959480950e-03*DaysPeryear,
+                                    vz = -2.96589568540237556e-05*DaysPeryear,
+                                    mass = 4.36624404335156298e-05*Solarmass,
+                                },
+                                new Body()
+                                {
+                                    // Neptune
+                                    x = 1.53796971148509165e+01,
+                                    y = -2.59193146099879641e+01,
+                                    z = 1.79258772950371181e-01,
+                                    vx = 2.68067772490389322e-03*DaysPeryear,
+                                    vy = 1.62824170038242295e-03*DaysPeryear,
+                                    vz = -9.51592254519715870e-05*DaysPeryear,
+                                    mass = 5.15138902046611451e-05*Solarmass,
+                                },
+                            };
+
+                            _pairL = new Body[(bodyCount * (bodyCount - 1) / 2)];
+                            _pairR = new Body[(bodyCount * (bodyCount - 1) / 2)];
+                            var pi = 0;
+                            for (var i = 0; i < bodyCount - 1; i++)
+                                for (var j = i + 1; j < bodyCount; j++)
+                                {
+                                    _pairL[pi] = _bodies[i];
+                                    _pairR[pi] = _bodies[j];
+                                    pi++;
+                                }
+
+                        double px = 0.0, py = 0.0, pz = 0.0;
+                            foreach (var b in _bodies)
+                            {
+                                px += b.vx * b.mass; py += b.vy * b.mass; pz += b.vz * b.mass;
+                            }
+                            var sol = _bodies[0];
+                            sol.vx = -px / Solarmass; sol.vy = -py / Solarmass; sol.vz = -pz / Solarmass;
+                        }
+
+                        public void Advance(double dt)
+                        {
+                            var length = _pairL.Length;
+                            for (int i = 0; i < length; i++)
+                            {
+                                Body bi =  _pairL[i], bj = _pairR[i];
+                                double dx = bi.x - bj.x, dy = bi.y - bj.y, dz = bi.z - bj.z;
+                                double d2 = dx * dx + dy * dy + dz * dz;
+                                double mag = dt / (d2 * Math.Sqrt(d2));
+                                bi.vx -= dx * bj.mass * mag; bj.vx += dx * bi.mass * mag;
+                                bi.vy -= dy * bj.mass * mag; bj.vy += dy * bi.mass * mag;
+                                bi.vz -= dz * bj.mass * mag; bj.vz += dz * bi.mass * mag;
+                            }
+                            foreach (var b in _bodies)
+                            {
+                                b.x += dt * b.vx; b.y += dt * b.vy; b.z += dt * b.vz;
+                            }
+                        }
+
+                        public double Energy()
+                        {
+                            double e = 0.0;
+                            for (int i = 0; i < bodyCount; i++)
+                            {
+                                var bi = _bodies[i];
+                                e += 0.5 * bi.mass * (bi.vx * bi.vx + bi.vy * bi.vy + bi.vz * bi.vz);
+                                for (int j = i + 1; j < bodyCount; j++)
+                                {
+                                    var bj = _bodies[j];
+                                    double dx = bi.x - bj.x, dy = bi.y - bj.y, dz = bi.z - bj.z;
+                                    e -= (bi.mass * bj.mass) / Math.Sqrt(dx * dx + dy * dy + dz * dz);
+                                }
+                            }
+                            return e;
+                        }
+                    }
+                }
+                """);
+  }
+}

--- a/tests/src/test/java/com/vztekoverflow/cilostazol/tests/BenchmarkValidityTests.java
+++ b/tests/src/test/java/com/vztekoverflow/cilostazol/tests/BenchmarkValidityTests.java
@@ -1,9 +1,11 @@
 package com.vztekoverflow.cilostazol.tests;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class BenchmarkValidityTests extends TestBase {
   @Test
+  @Disabled
   public void nBody() {
     var result =
         runTestFromCode(


### PR DESCRIPTION
Interpreter: Add custom method implementation support

In an effort to correctly run benchmarks, it is required we support 
runtime-specific methods. Support for custom implementations 
was added, `System.Math` methods we implemented.